### PR TITLE
Fix/Set RDK static library to the correct path

### DIFF
--- a/flexiv_hardware/CMakeLists.txt
+++ b/flexiv_hardware/CMakeLists.txt
@@ -10,8 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-option(BUILD_FOR_ARM64 "Link to RDK library for arm64 processor, otherwise link to x64" OFF)
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -31,14 +29,34 @@ target_include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/rdk/include
 )
 
-# Link arm64 or x64 version of libFlexivRdk
-if (${BUILD_FOR_ARM64})
-  target_link_libraries(${PROJECT_NAME}
-    ${CMAKE_CURRENT_SOURCE_DIR}/rdk/lib/libFlexivRdk.arm64-darwin.a)
-else()
-  target_link_libraries(${PROJECT_NAME}
-    ${CMAKE_CURRENT_SOURCE_DIR}/rdk/lib/libFlexivRdk.x86_64-linux-gnu.a)
+# Set static library
+message("OS: ${CMAKE_SYSTEM_NAME}")
+message("Processor: ${CMAKE_SYSTEM_PROCESSOR}")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+    set(RDK_STATIC_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/rdk/lib/libFlexivRdk.x86_64-linux-gnu.a")
+  elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+    set(RDK_STATIC_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/rdk/lib/libFlexivRdk.aarch64-linux-gnu.a")
+  else()
+    message(FATAL_ERROR "Linux with ${CMAKE_SYSTEM_PROCESSOR} processor is currently not supported.")
+  endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
+    set(RDK_STATIC_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/rdk/lib/libFlexivRdk.arm64-darwin.a")
+  else()
+    message(FATAL_ERROR "Mac with ${CMAKE_SYSTEM_PROCESSOR} processor is currently not supported.")
+  endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "AMD64")
+    set(RDK_STATIC_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/rdk/lib/FlexivRdk.win_amd64.lib")
+  else()
+    message(FATAL_ERROR "Windows with ${CMAKE_SYSTEM_PROCESSOR} processor is currently not supported.")
+  endif()
 endif()
+
+target_link_libraries(${PROJECT_NAME}
+  ${RDK_STATIC_LIBRARY}
+)
 
 # Link ROS packages
 ament_target_dependencies(


### PR DESCRIPTION
Fix issue #15 due to the wrong RDK static library linked to the ROS package `flexiv_hardware`. The correct RDK static library for different OS and processors is as follows:
- Linux x86_64: [libFlexivRdk.x86_64-linux-gnu.a](https://github.com/flexivrobotics/flexiv_rdk/blob/main/lib/libFlexivRdk.x86_64-linux-gnu.a)
- Linux arm64 (aarch64): [libFlexivRdk.aarch64-linux-gnu.a](https://github.com/flexivrobotics/flexiv_rdk/blob/main/lib/libFlexivRdk.aarch64-linux-gnu.a)
- macOS arm64: [libFlexivRdk.arm64-darwin.a](https://github.com/flexivrobotics/flexiv_rdk/blob/main/lib/libFlexivRdk.arm64-darwin.a)
- Windows amd64: [FlexivRdk.win_amd64.lib](https://github.com/flexivrobotics/flexiv_rdk/blob/main/lib/FlexivRdk.win_amd64.lib)

Update the `CMakeLists.txt` to set the RDK library automatically, so the parameter `BUILD_FOR_ARM64` is not required. #14 