### PR TITLE
Bugfix/Add missing sensor interfaces in Rizon 10 ros2_control xacro

### DIFF
--- a/flexiv_description/urdf/rizon10.ros2_control.xacro
+++ b/flexiv_description/urdf/rizon10.ros2_control.xacro
@@ -124,6 +124,41 @@
         <param name="initial_position">${initial_positions['joint7']}</param>        <!-- initial position for the FakeSystem -->
       </joint>
 
+      <sensor name="${prefix}force_torque_sensor">
+        <state_interface name="force.x"/>
+        <state_interface name="force.y"/>
+        <state_interface name="force.z"/>
+        <state_interface name="torque.x"/>
+        <state_interface name="torque.y"/>
+        <state_interface name="torque.z"/>
+      </sensor>
+      <sensor name="${prefix}external_wrench_in_base">
+        <state_interface name="force.x"/>
+        <state_interface name="force.y"/>
+        <state_interface name="force.z"/>
+        <state_interface name="torque.x"/>
+        <state_interface name="torque.y"/>
+        <state_interface name="torque.z"/>
+      </sensor>
+      <sensor name="${prefix}external_wrench_in_tcp">
+        <state_interface name="force.x"/>
+        <state_interface name="force.y"/>
+        <state_interface name="force.z"/>
+        <state_interface name="torque.x"/>
+        <state_interface name="torque.y"/>
+        <state_interface name="torque.z"/>
+      </sensor>
+
+      <sensor name="${prefix}tcp_pose">
+        <state_interface name="position.x"/>
+        <state_interface name="position.y"/>
+        <state_interface name="position.z"/>
+        <state_interface name="orientation.x"/>
+        <state_interface name="orientation.y"/>
+        <state_interface name="orientation.z"/>
+        <state_interface name="orientation.w"/>
+      </sensor>
+
     </ros2_control>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Add missing sensor interfaces which are used by the sensor states braodcasters in `rizon10.ros2_control.xacro`