### PR TITLE
Feature/Add MoveIt Servo Config

### DIFF
--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -308,6 +308,7 @@ def generate_launch_description():
             servo_params,
             robot_description,
             robot_description_semantic,
+            robot_description_kinematics,
         ],
         output="screen",
     )

--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -5,7 +5,12 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -17,7 +22,9 @@ def load_yaml(package_name, file_path):
     try:
         with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+    except (
+        EnvironmentError
+    ):  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
@@ -47,7 +54,7 @@ def generate_launch_description():
             description="IP address of the workstation PC (local).",
         )
     )
-    
+
     declared_arguments.append(
         DeclareLaunchArgument(
             "start_rviz",
@@ -72,12 +79,20 @@ def generate_launch_description():
             Used only if 'use_fake_hardware' parameter is true.",
         )
     )
-    
+
     declared_arguments.append(
         DeclareLaunchArgument(
             "warehouse_sqlite_path",
             default_value=os.path.expanduser("~/.ros/warehouse_ros.sqlite"),
             description="Path to the sqlite database used by the warehouse_ros package.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "start_servo",
+            default_value="false",
+            description="Start the MoveIt servo node?",
         )
     )
 
@@ -88,6 +103,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     warehouse_sqlite_path = LaunchConfiguration("warehouse_sqlite_path")
+    start_servo = LaunchConfiguration("start_servo")
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
@@ -125,7 +141,7 @@ def generate_launch_description():
     flexiv_srdf_xacro = PathJoinSubstitution(
         [FindPackageShare("flexiv_moveit_config"), "srdf", "rizon.srdf.xacro"]
     )
-    
+
     robot_description_semantic_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -243,12 +259,12 @@ def generate_launch_description():
         output="both",
         parameters=[robot_description],
     )
-    
+
     # Robot controllers
     robot_controllers = PathJoinSubstitution(
         [FindPackageShare("flexiv_bringup"), "config", "rizon_controllers.yaml"]
     )
-    
+
     # Run controller manager
     ros2_control_node = Node(
         package="controller_manager",
@@ -256,19 +272,42 @@ def generate_launch_description():
         parameters=[robot_description, robot_controllers],
         output="both",
     )
-    
+
     # Run robot controller
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["rizon_arm_controller", "--controller-manager", "/controller_manager"],
+        arguments=[
+            "rizon_arm_controller",
+            "--controller-manager",
+            "/controller_manager",
+        ],
     )
-    
+
     # Run joint state broadcaster
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    # Servo node for realtime control
+    servo_yaml = load_yaml("flexiv_moveit_config", "config/servo.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
+    servo_node = Node(
+        package="moveit_servo",
+        condition=IfCondition(start_servo),
+        executable="servo_node_main",
+        parameters=[
+            servo_params,
+            robot_description,
+            robot_description_semantic,
+        ],
+        output="screen",
     )
 
     nodes = [
@@ -278,6 +317,7 @@ def generate_launch_description():
         joint_state_broadcaster_spawner,
         robot_controller_spawner,
         rviz_node,
+        servo_node,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -296,7 +296,9 @@ def generate_launch_description():
     )
 
     # Servo node for realtime control
-    servo_yaml = load_yaml("flexiv_moveit_config", "config/servo.yaml")
+    servo_yaml = load_yaml(
+        "flexiv_moveit_config", "config/rizon_moveit_servo_config.yaml"
+    )
     servo_params = {"moveit_servo": servo_yaml}
     servo_node = Node(
         package="moveit_servo",

--- a/flexiv_moveit_config/config/rizon_moveit_servo_config.yaml
+++ b/flexiv_moveit_config/config/rizon_moveit_servo_config.yaml
@@ -1,0 +1,71 @@
+###############################################
+# Modify all parameters related to servoing here
+###############################################
+use_gazebo: false # Whether the robot is started in a Gazebo simulation environment
+
+## Properties of incoming commands
+command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
+scale:
+  # Scale parameters are only used if command_in_type=="unitless"
+  linear:  0.4  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
+  joint: 0.5
+
+# Optionally override Servo's internal velocity scaling when near singularity or collision (0.0 = use internal velocity scaling)
+# override_velocity_scaling_factor = 0.0 # valid range [0.0:1.0]
+
+## Properties of outgoing commands
+publish_period: 0.034  # 1/Nominal publish rate [seconds]
+low_latency_mode: false  # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)
+
+# What type of topic does your robot driver expect?
+# Currently supported are std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory
+command_out_type: trajectory_msgs/JointTrajectory
+
+# What to publish? Can save some bandwidth as most robots only require positions or velocities
+publish_joint_positions: true
+publish_joint_velocities: true
+publish_joint_accelerations: false
+
+## Plugins for smoothing outgoing commands
+smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
+
+# If is_primary_planning_scene_monitor is set to true, the Servo server's PlanningScene advertises the /get_planning_scene service,
+# which other nodes can use as a source for information about the planning environment.
+# NOTE: If a different node in your system is responsible for the "primary" planning scene instance (e.g. the MoveGroup node),
+# then is_primary_planning_scene_monitor needs to be set to false.
+is_primary_planning_scene_monitor: true
+
+## MoveIt properties
+move_group_name:  rizon_arm  # Often 'manipulator' or 'arm'
+planning_frame: base_link # The MoveIt planning frame. Often 'base_link' or 'world'
+
+## Other frames
+ee_frame_name: flange  # The name of the end effector link, used to return the EE pose
+robot_link_command_frame:  flange  # commands must be given in the frame of a robot link. Usually either the base or end effector
+
+## Stopping behaviour
+incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
+# If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
+# Important because ROS may drop some messages and we need the robot to halt reliably.
+num_outgoing_halt_msgs_to_publish: 4
+
+## Configure handling of singularities and joint limits
+lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)
+hard_stop_singularity_threshold: 30.0 # Stop when the condition number hits this
+joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
+leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
+
+## Topic names
+cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands
+joint_command_in_topic: ~/delta_joint_cmds # Topic for incoming joint angle commands
+joint_topic: /joint_states
+status_topic: ~/status # Publish status to this topic
+command_out_topic: /rizon_arm_controller/joint_trajectory # Publish outgoing commands here
+
+## Collision checking for the entire robot body
+check_collisions: true # Check collisions?
+collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
+scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]

--- a/flexiv_moveit_config/package.xml
+++ b/flexiv_moveit_config/package.xml
@@ -18,6 +18,8 @@
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_servo</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>flexiv_description</exec_depend>
   <exec_depend>urdf</exec_depend>

--- a/flexiv_moveit_config/srdf/rizon_macro.srdf.xacro
+++ b/flexiv_moveit_config/srdf/rizon_macro.srdf.xacro
@@ -36,5 +36,6 @@
         <disable_collisions link1="${prefix}link4" link2="${prefix}link7" reason="Never"/>
         <disable_collisions link1="${prefix}link5" link2="${prefix}link6" reason="Adjacent"/>
         <disable_collisions link1="${prefix}link6" link2="${prefix}link7" reason="Adjacent"/>
+        <disable_collisions link1="${prefix}link7" link2="${prefix}flange" reason="Adjacent"/>
     </xacro:macro>
 </robot>


### PR DESCRIPTION
## ADD
- Add Rizon config file for MoveIt Servo: _flexiv_moveit_config/config/rizon_moveit_servo_config.yaml_
- Add launch parameter "_start_servo_" in rizon_moveit launch file

## Example

In order to start realtime arm servoing with MoveIt Servo, please refer to the MoveIt documentation: [Realtime Arm Servoing](https://moveit.picknik.ai/humble/doc/examples/realtime_servo/realtime_servo_tutorial.html#realtime-arm-servoing).
1. Change the joint trajectory controller to velocity command interface in _flexiv_bringup/config/rizon_controllers.yaml_
```yaml
rizon_arm_controller:
  ros__parameters:
    joints:
      - joint1
      - joint2
      - joint3
      - joint4
      - joint5
      - joint6
      - joint7
    command_interfaces:
      - velocity
    state_interfaces:
      - position
      - velocity
    state_publish_rate: 100.0
    action_monitor_rate: 20.0
    allow_partial_joints_goal: false
    constraints:
      stopped_velocity_tolerance: 0.01
      goal_time: 0.0
    gains:
      joint1: {ff_velocity_scale: 1.0}
      joint2: {ff_velocity_scale: 1.0}
      joint3: {ff_velocity_scale: 1.0}
      joint4: {ff_velocity_scale: 1.0}
      joint5: {ff_velocity_scale: 1.0}
      joint6: {ff_velocity_scale: 1.0}
      joint7: {ff_velocity_scale: 1.0}
```

2. Launch Moveit with "start_servo" enabled:
```
ros2 launch flexiv_bringup rizon_moveit.launch.py robot_ip:=[robot_ip] local_ip:=[local_ip] start_servo:=true
```

3. Send a service request to start Servo:
```
ros2 service call /servo_node/start_servo std_srvs/srv/Trigger {}
```

4. Send commands to the servo node to test if the robot moves, for example:
```
ros2 topic pub /servo_node/delta_twist_cmds geometry_msgs/msg/TwistStamped "{ header: { stamp: 'now' },  twist: {linear: {x: 0.1}, angular: {  }}}" -r 10
```