### PR TITLE
Add controller_manager package in flexiv_bringup package.xml

### DIFF
--- a/flexiv_bringup/package.xml
+++ b/flexiv_bringup/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>controller_manager</exec_depend>
   <exec_depend>flexiv_description</exec_depend>
   <exec_depend>flexiv_hardware</exec_depend>
   <exec_depend>flexiv_robot_states_broadcaster</exec_depend>


### PR DESCRIPTION
PR info:
- adds as `<exec_depend>`  `controller_manager` node which is necessary for starting `ros2_control_node` and `spawner`.
- no need to run manually installation of ROS 2 packages - rosdep does this for you using: `rosdep install --from-paths ./src --ignore-src -y -r`