### PR TITLE
Feature/Update RobotStates.msg to include robot timestamp

### DIFF
--- a/flexiv_controllers/flexiv_robot_states_broadcaster/include/flexiv_robot_states_broadcaster/flexiv_robot_states.hpp
+++ b/flexiv_controllers/flexiv_robot_states_broadcaster/include/flexiv_robot_states_broadcaster/flexiv_robot_states.hpp
@@ -70,6 +70,8 @@ public:
         message.ft_sensor_raw.header.frame_id = name_ + "_" + kFlangeFrameId;
         message.ext_wrench_in_tcp.header.frame_id = name_ + "_" + kFlangeFrameId;
         message.ext_wrench_in_world.header.frame_id = name_ + "_" + kFlangeFrameId;
+        message.ext_wrench_in_tcp_raw.header.frame_id = name_ + "_" + kFlangeFrameId;
+        message.ext_wrench_in_world_raw.header.frame_id = name_ + "_" + kFlangeFrameId;
     }
 
     /// Return RobotStates message
@@ -100,8 +102,13 @@ public:
         message.ft_sensor_raw.header.stamp = message.header.stamp;
         message.ext_wrench_in_tcp.header.stamp = message.header.stamp;
         message.ext_wrench_in_world.header.stamp = message.header.stamp;
+        message.ext_wrench_in_tcp_raw.header.stamp = message.header.stamp;
+        message.ext_wrench_in_world_raw.header.stamp = message.header.stamp;
 
         // Fill the RobotStates message
+        message.robot_timestamp.sec = flexiv_robot_states_ptr->timestamp.first;
+        message.robot_timestamp.nanosec = flexiv_robot_states_ptr->timestamp.second;
+
         message.q = toJointStateMsg(flexiv_robot_states_ptr->q);
         message.theta = toJointStateMsg(flexiv_robot_states_ptr->theta);
         message.dq = toJointStateMsg(flexiv_robot_states_ptr->dq);
@@ -110,6 +117,8 @@ public:
         message.tau_des = toJointStateMsg(flexiv_robot_states_ptr->tau_des);
         message.tau_dot = toJointStateMsg(flexiv_robot_states_ptr->tau_dot);
         message.tau_ext = toJointStateMsg(flexiv_robot_states_ptr->tau_ext);
+        message.tau_interact = toJointStateMsg(flexiv_robot_states_ptr->tau_interact);
+        message.temperature = toJointStateMsg(flexiv_robot_states_ptr->temperature);
 
         message.tcp_pose.pose = toPoseMsg(flexiv_robot_states_ptr->tcp_pose);
         message.tcp_vel.accel = toAccelMsg(flexiv_robot_states_ptr->tcp_vel);
@@ -118,6 +127,10 @@ public:
         message.ext_wrench_in_tcp.wrench = toWrenchMsg(flexiv_robot_states_ptr->ext_wrench_in_tcp);
         message.ext_wrench_in_world.wrench
             = toWrenchMsg(flexiv_robot_states_ptr->ext_wrench_in_world);
+        message.ext_wrench_in_tcp_raw.wrench
+            = toWrenchMsg(flexiv_robot_states_ptr->ext_wrench_in_tcp_raw);
+        message.ext_wrench_in_world_raw.wrench
+            = toWrenchMsg(flexiv_robot_states_ptr->ext_wrench_in_world_raw);
 
         return true;
     }

--- a/flexiv_controllers/flexiv_robot_states_broadcaster/include/flexiv_robot_states_broadcaster/flexiv_robot_states.hpp
+++ b/flexiv_controllers/flexiv_robot_states_broadcaster/include/flexiv_robot_states_broadcaster/flexiv_robot_states.hpp
@@ -69,9 +69,9 @@ public:
         message.flange_pose.header.frame_id = kWorldFrameId;
         message.ft_sensor_raw.header.frame_id = name_ + "_" + kFlangeFrameId;
         message.ext_wrench_in_tcp.header.frame_id = name_ + "_" + kFlangeFrameId;
-        message.ext_wrench_in_world.header.frame_id = name_ + "_" + kFlangeFrameId;
+        message.ext_wrench_in_world.header.frame_id = kWorldFrameId;
         message.ext_wrench_in_tcp_raw.header.frame_id = name_ + "_" + kFlangeFrameId;
-        message.ext_wrench_in_world_raw.header.frame_id = name_ + "_" + kFlangeFrameId;
+        message.ext_wrench_in_world_raw.header.frame_id = kWorldFrameId;
     }
 
     /// Return RobotStates message

--- a/flexiv_hardware/src/flexiv_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_hardware_interface.cpp
@@ -273,7 +273,7 @@ hardware_interface::CallbackReturn FlexivHardwareInterface::on_deactivate(
 hardware_interface::return_type FlexivHardwareInterface::read(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
 {
-    if (robot_->operational() && robot_->mode() != flexiv::rdk::Mode::IDLE) {
+    if (robot_->operational()) {
 
         hw_flexiv_robot_states_ = robot_->states();
 

--- a/flexiv_msgs/msg/RobotStates.msg
+++ b/flexiv_msgs/msg/RobotStates.msg
@@ -1,6 +1,9 @@
 # Header
 std_msgs/Header header
 
+# Robot system timestamp
+builtin_interfaces/Time robot_timestamp
+
 # Measured joint positions using link-side encoder
 float64[7] q
 
@@ -25,6 +28,12 @@ float64[7] tau_dot
 # Estimated external joint torques
 float64[7] tau_ext
 
+# Estimated interaction joint torques
+float64[7] tau_interact
+
+# Measured joint temperatures
+float64[7] temperature
+
 # Measured TCP pose expressed in world frame
 geometry_msgs/PoseStamped tcp_pose
 
@@ -42,3 +51,9 @@ geometry_msgs/WrenchStamped ext_wrench_in_tcp
 
 # Estimated external wrench applied on TCP and expressed in world frame
 geometry_msgs/WrenchStamped ext_wrench_in_world
+
+# Unfiltered external wrench applied on TCP and expressed in TCP frame
+geometry_msgs/WrenchStamped ext_wrench_in_tcp_raw
+
+# Unfiltered external wrench applied on TCP and expressed in world frame
+geometry_msgs/WrenchStamped ext_wrench_in_world_raw

--- a/flexiv_test_nodes/flexiv_test_nodes/robot_states_publisher.py
+++ b/flexiv_test_nodes/flexiv_test_nodes/robot_states_publisher.py
@@ -178,8 +178,8 @@ class RobotStatesPublisher(Node):
             msg.header.frame_id = "world"
 
             # Robot timestamp
-            msg.robot_timestamp.sec = robot_states.robot_timestamp[0]
-            msg.robot_timestamp.nanosec = robot_states.robot_timestamp[1]
+            msg.robot_timestamp.sec = robot_states.timestamp[0]
+            msg.robot_timestamp.nanosec = robot_states.timestamp[1]
 
             # Joint-space states (all arrays are size 7 for Flexiv robots)
             msg.q = list(robot_states.q)  # Joint positions (link-side)

--- a/flexiv_test_nodes/flexiv_test_nodes/robot_states_publisher.py
+++ b/flexiv_test_nodes/flexiv_test_nodes/robot_states_publisher.py
@@ -15,7 +15,6 @@ import argparse
 
 # Import ROS2 message types
 from flexiv_msgs.msg import RobotStates
-from std_msgs.msg import Header
 from geometry_msgs.msg import PoseStamped, AccelStamped, WrenchStamped
 
 
@@ -178,6 +177,10 @@ class RobotStatesPublisher(Node):
             msg.header.stamp = self.get_clock().now().to_msg()
             msg.header.frame_id = "world"
 
+            # Robot timestamp
+            msg.robot_timestamp.sec = robot_states.robot_timestamp[0]
+            msg.robot_timestamp.nanosec = robot_states.robot_timestamp[1]
+
             # Joint-space states (all arrays are size 7 for Flexiv robots)
             msg.q = list(robot_states.q)  # Joint positions (link-side)
             msg.theta = list(robot_states.theta)  # Joint positions (motor-side)
@@ -187,6 +190,10 @@ class RobotStatesPublisher(Node):
             msg.tau_des = list(robot_states.tau_des)  # Desired joint torques
             msg.tau_dot = list(robot_states.tau_dot)  # Joint torque derivatives
             msg.tau_ext = list(robot_states.tau_ext)  # External joint torques
+            msg.tau_interact = list(
+                robot_states.tau_interact
+            )  # Interaction joint torques
+            msg.temperature = list(robot_states.temperature)  # Joint temperatures
 
             # Cartesian-space states using geometry_msgs
             # TCP pose: [x, y, z, q_w, q_x, q_y, q_z]
@@ -207,12 +214,22 @@ class RobotStatesPublisher(Node):
 
             # External wrench in TCP frame: [f_x, f_y, f_z, m_x, m_y, m_z]
             msg.ext_wrench_in_tcp = self.create_wrench_stamped(
-                robot_states.ext_wrench_in_tcp, "tcp"
+                robot_states.ext_wrench_in_tcp, "flange"
             )
 
             # External wrench in world frame: [f_x, f_y, f_z, m_x, m_y, m_z]
             msg.ext_wrench_in_world = self.create_wrench_stamped(
                 robot_states.ext_wrench_in_world, "world"
+            )
+
+            # External wrench in TCP frame (raw): [f_x, f_y, f_z, m_x, m_y, m_z]
+            msg.ext_wrench_in_tcp_raw = self.create_wrench_stamped(
+                robot_states.ext_wrench_in_tcp_raw, "flange"
+            )
+
+            # External wrench in world frame (raw): [f_x, f_y, f_z, m_x, m_y, m_z]
+            msg.ext_wrench_in_world_raw = self.create_wrench_stamped(
+                robot_states.ext_wrench_in_world_raw, "world"
             )
 
             # Publish the message


### PR DESCRIPTION
- Update `RobotStates` message to include robot timestamp and additional robot state parameters
- Update `robot_states_publisher` to publish updated `RobotStates` message
- Bugfix:
  - Remove RDK IDLE mode check in `read()` function of `FlexivHardwareInterface` 
  - Fix wrong `frame_id` assignment for external wrench messages in `RobotStates`