### PR TITLE
Feature/Add DRDK hardware interface in flexiv_hardware

### DIFF
--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -48,6 +48,7 @@ jobs:
           cd flexiv_rdk
           git checkout release/v1.9
           cd thirdparty
+          source /opt/ros/humble/setup.bash
           bash build_and_install_dependencies_not_in_ros2.sh ~/rdk_install
           cd ..
           mkdir -p build && cd build
@@ -60,6 +61,7 @@ jobs:
           cd flexiv_drdk
           git checkout v1.1
           cd thirdparty
+          source /opt/ros/humble/setup.bash
           bash build_and_install_dependencies.sh ~/drdk_install
           cd ..
           mkdir -p build && cd build

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -34,12 +34,12 @@ jobs:
           ros-humble-joint-state-publisher-gui \
           ros-humble-moveit \
           ros-humble-realtime-tools \
-          ros-humble-robot-state-publisher
+          ros-humble-robot-state-publisher \
           ros-humble-ros2-control \
           ros-humble-ros2-controllers \
           ros-humble-test-msgs \
           ros-humble-tinyxml2-vendor \
-          ros-humble-xacro \
+          ros-humble-xacro
       - name: Build and install flexiv_rdk
         shell: bash
         run: |

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y \
+          wget \
           libeigen3-dev \
           ros-humble-control-toolbox \
           ros-humble-hardware-interface \

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - humble
+      - release/humble-*
 
 jobs:
   humble_binary:
@@ -27,17 +28,18 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
           libeigen3-dev \
-          ros-humble-xacro \
-          ros-humble-tinyxml2-vendor \
-          ros-humble-ros2-control \
-          ros-humble-realtime-tools \
           ros-humble-control-toolbox \
-          ros-humble-moveit \
-          ros-humble-ros2-controllers \
-          ros-humble-test-msgs \
+          ros-humble-hardware-interface \
           ros-humble-joint-state-publisher \
           ros-humble-joint-state-publisher-gui \
+          ros-humble-moveit \
+          ros-humble-realtime-tools \
           ros-humble-robot-state-publisher
+          ros-humble-ros2-control \
+          ros-humble-ros2-controllers \
+          ros-humble-test-msgs \
+          ros-humble-tinyxml2-vendor \
+          ros-humble-xacro \
       - name: Build and install flexiv_rdk
         shell: bash
         run: |

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -43,11 +43,26 @@ jobs:
       - name: Build and install flexiv_rdk
         shell: bash
         run: |
-          cd flexiv_hardware/rdk/thirdparty
-          bash build_and_install_dependencies.sh ~/rdk_install
+          git clone https://github.com/flexivrobotics/flexiv_rdk.git
+          cd flexiv_rdk
+          git checkout release/v1.9
+          cd thirdparty
+          bash build_and_install_dependencies_not_in_ros2.sh ~/rdk_install
           cd ..
           mkdir -p build && cd build
           cmake .. -DCMAKE_INSTALL_PREFIX=~/rdk_install
+          cmake --build . --target install --config Release
+      - name: Build and install flexiv_drdk
+        shell: bash
+        run: |
+          git clone https://github.com/flexivrobotics/flexiv_drdk.git
+          cd flexiv_drdk
+          git checkout v1.1
+          cd thirdparty
+          bash build_and_install_dependencies.sh ~/drdk_install
+          cd ..
+          mkdir -p build && cd build
+          cmake .. -DCMAKE_INSTALL_PREFIX=~/drdk_install
           cmake --build . --target install --config Release
       - name: Build and run tests
         id: action-ros-ci
@@ -68,7 +83,7 @@ jobs:
             {
               "build": {
                 "cmake-args": [
-                    "-DCMAKE_PREFIX_PATH=~/rdk_install"
+                    "-DCMAKE_PREFIX_PATH=~/rdk_install;~/drdk_install"
                 ]
               }
             }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "flexiv_hardware/rdk"]
-	path = flexiv_hardware/rdk
-	url = https://github.com/flexivrobotics/flexiv_rdk
-	branch = main

--- a/README.md
+++ b/README.md
@@ -87,35 +87,6 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    cmake --build . --target install --config Release
    ```
 
-> [!NOTE]
-> (Optional) If you are using a Flexiv dual robot setup, you can install `flexiv_drdk` as well.
->
-> 1. Clone `flexiv_drdk` into the workspace source directory and ignore it from colcon build:
->
->    ```bash
->    cd ~/flexiv_ros2_ws/src
->    git clone https://github.com/flexivrobotics/flexiv_drdk.git
->    cd flexiv_drdk
->    git checkout v1.1
->    touch COLCON_IGNORE
->    ```
->
-> 2. Install dependencies and build `flexiv_drdk` by choosing an installation directory, e.g., `~/drdk_install`:
->
->    ```bash
->    cd ~/flexiv_ros2_ws/src/flexiv_drdk/thirdparty
->    bash build_and_install_dependencies.sh ~/drdk_install
->    ```
->
-> 3. Configure and install `flexiv_drdk`:
->
->    ```bash
->    cd ~/flexiv_ros2_ws/src/flexiv_drdk
->    mkdir build && cd build
->    cmake .. -DCMAKE_INSTALL_PREFIX=~/drdk_install
->    cmake --build . --target install --config Release
->    ```
-
 7. Build and source the workspace:
 
    ```bash
@@ -125,14 +96,46 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    source install/setup.bash
    ```
 
-   If `flexiv_drdk` is installed, add its installation path to `CMAKE_PREFIX_PATH`:
+### Flexiv DRDK Installation (Optional)
+
+If you are using a Flexiv dual robot setup, you can install `flexiv_drdk` as well.
+
+1. Clone `flexiv_drdk` into the workspace source directory and ignore it from colcon build:
 
    ```bash
+   cd ~/flexiv_ros2_ws/src
+   git clone https://github.com/flexivrobotics/flexiv_drdk.git
+   cd flexiv_drdk
+   git checkout v1.1
+   touch COLCON_IGNORE
+   ```
+
+2. Install dependencies and build `flexiv_drdk` by choosing an installation directory, e.g., `~/drdk_install`:
+
+   ```bash
+   cd ~/flexiv_ros2_ws/src/flexiv_drdk/thirdparty
+   bash build_and_install_dependencies.sh ~/drdk_install
+   ```
+
+3. Configure and install `flexiv_drdk`:
+
+   ```bash
+   cd ~/flexiv_ros2_ws/src/flexiv_drdk
+   mkdir build && cd build
+   cmake .. -DCMAKE_INSTALL_PREFIX=~/drdk_install
+   cmake --build . --target install --config Release
+   ```
+
+4. Rebuild the workspace with both RDK and DRDK installation paths:
+
+   ```bash
+   cd ~/flexiv_ros2_ws
    colcon build --symlink-install --cmake-args -DCMAKE_PREFIX_PATH="~/rdk_install;~/drdk_install"
    ```
 
-> [!NOTE]
+> [!IMPORTANT]
 > Remember to source the setup file and the workspace whenever a new terminal is opened:
+>
 > ```bash
 > source /opt/ros/humble/setup.bash
 > source ~/flexiv_ros2_ws/install/setup.bash

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    ```bash
    cd ~/flexiv_ros2_ws
    vcs import src < src/flexiv_ros2/flexiv.humble.repos --recursive --skip-existing
+   touch src/flexiv_rdk/COLCON_IGNORE
    rosdep update
    rosdep install --from-paths src --ignore-src --rosdistro humble -r -y
    ```
@@ -86,6 +87,35 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    cmake --build . --target install --config Release
    ```
 
+> [!NOTE]
+> (Optional) If you are using a Flexiv dual robot setup, you can install `flexiv_drdk` as well.
+>
+> 1. Clone `flexiv_drdk` into the workspace source directory and ignore it from colcon build:
+>
+>    ```bash
+>    cd ~/flexiv_ros2_ws/src
+>    git clone https://github.com/flexivrobotics/flexiv_drdk.git
+>    cd flexiv_drdk
+>    git checkout v1.1
+>    touch COLCON_IGNORE
+>    ```
+>
+> 2. Install dependencies and build `flexiv_drdk` by choosing an installation directory, e.g., `~/drdk_install`:
+>
+>    ```bash
+>    cd ~/flexiv_ros2_ws/src/flexiv_drdk/thirdparty
+>    bash build_and_install_dependencies.sh ~/drdk_install
+>    ```
+>
+> 3. Configure and install `flexiv_drdk`:
+>
+>    ```bash
+>    cd ~/flexiv_ros2_ws/src/flexiv_drdk
+>    mkdir build && cd build
+>    cmake .. -DCMAKE_INSTALL_PREFIX=~/drdk_install
+>    cmake --build . --target install --config Release
+>    ```
+
 7. Build and source the workspace:
 
    ```bash
@@ -93,6 +123,12 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    source /opt/ros/humble/setup.bash
    colcon build --symlink-install --cmake-args -DCMAKE_PREFIX_PATH=~/rdk_install
    source install/setup.bash
+   ```
+
+   If `flexiv_drdk` is installed, add its installation path to `CMAKE_PREFIX_PATH`:
+
+   ```bash
+   colcon build --symlink-install --cmake-args -DCMAKE_PREFIX_PATH="~/rdk_install;~/drdk_install"
    ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    ros-humble-robot-state-publisher \
    ros-humble-ros2-control \
    ros-humble-ros2-controllers \
-   ros-humble-rviz2
+   ros-humble-rviz2 \
    ros-humble-test-msgs \
    ros-humble-tinyxml2-vendor \
    ros-humble-xacro \

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ Test with fake hardware:
 ros2 launch flexiv_bringup rizon_moveit.launch.py robot_sn:=Rizon4-123456 use_fake_hardware:=true
 ```
 
+With dual robot setup:
+
+```bash
+ros2 launch flexiv_bringup rizon_dual_moveit.launch.py robot_sn_left:=Rizon4-123456 robot_sn_right:=Rizon4R-654321
+```
+
 ### Robot States
 
 The robot driver (`rizon.launch.py`) publishes the following feedback states to the respective ROS topics:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
 
    ```bash
    cd ~/flexiv_ros2_ws/src/flexiv_rdk/thirdparty
-   bash build_and_install_dependencies.sh ~/rdk_install
+   bash build_and_install_dependencies_not_in_ros2.sh ~/rdk_install
    ```
 
 6. Configure and install `flexiv_rdk`:

--- a/README.md
+++ b/README.md
@@ -36,18 +36,19 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    python3-colcon-common-extensions \
    python3-rosdep2 \
    libeigen3-dev \
-   ros-humble-xacro \
-   ros-humble-tinyxml2-vendor \
-   ros-humble-ros2-control \
-   ros-humble-realtime-tools \
    ros-humble-control-toolbox \
-   ros-humble-moveit \
-   ros-humble-ros2-controllers \
-   ros-humble-test-msgs \
+   ros-humble-hardware-interface \
    ros-humble-joint-state-publisher \
    ros-humble-joint-state-publisher-gui \
+   ros-humble-moveit \
+   ros-humble-realtime-tools \
    ros-humble-robot-state-publisher \
+   ros-humble-ros2-control \
+   ros-humble-ros2-controllers \
    ros-humble-rviz2
+   ros-humble-test-msgs \
+   ros-humble-tinyxml2-vendor \
+   ros-humble-xacro \
    ```
 
 3. Setup workspace:
@@ -67,9 +68,6 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    rosdep update
    rosdep install --from-paths src --ignore-src --rosdistro humble -r -y
    ```
-
-> [!NOTE]
-> Skip step 5 and 6 if you have compile and install [flexiv_rdk](https://github.com/flexivrobotics/flexiv_rdk).
 
 5. Choose a directory for installing `flexiv_rdk` library and all its dependencies. For example, a new folder named `rdk_install` under the home directory: `~/rdk_install`. Compile and install to the installation directory:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
 
    ```bash
    cd ~/flexiv_ros2_ws/src/flexiv_rdk
-   mkdir build && cd build
+   rm -rf build && mkdir build && cd build
    cmake .. -DCMAKE_INSTALL_PREFIX=~/rdk_install
    cmake --build . --target install --config Release
    ```
@@ -119,7 +119,7 @@ If you are using a Flexiv dual robot setup, you can install `flexiv_drdk` as wel
 
    ```bash
    cd ~/flexiv_ros2_ws/src/flexiv_drdk
-   mkdir build && cd build
+   rm -rf build && mkdir build && cd build
    cmake .. -DCMAKE_INSTALL_PREFIX=~/drdk_install
    cmake --build . --target install --config Release
    ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
 
    ```bash
    cd ~/flexiv_ros2_ws/src/flexiv_rdk/thirdparty
+   source /opt/ros/humble/setup.bash
    bash build_and_install_dependencies_not_in_ros2.sh ~/rdk_install
    ```
 
@@ -112,6 +113,7 @@ If you are using a Flexiv dual robot setup, you can install `flexiv_drdk` as wel
 
    ```bash
    cd ~/flexiv_ros2_ws/src/flexiv_drdk/thirdparty
+   source /opt/ros/humble/setup.bash
    bash build_and_install_dependencies.sh ~/drdk_install
    ```
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
    mkdir -p ~/flexiv_ros2_ws/src
    cd ~/flexiv_ros2_ws/src
    git clone https://github.com/flexivrobotics/flexiv_ros2.git
-   cd flexiv_ros2/
-   git submodule update --init --recursive
    ```
 
 4. Install dependencies:
@@ -75,14 +73,14 @@ This project was developed for ROS 2 Foxy (Ubuntu 20.04), Humble (Ubuntu 22.04) 
 5. Choose a directory for installing `flexiv_rdk` library and all its dependencies. For example, a new folder named `rdk_install` under the home directory: `~/rdk_install`. Compile and install to the installation directory:
 
    ```bash
-   cd ~/flexiv_ros2_ws/src/flexiv_ros2/flexiv_hardware/rdk/thirdparty
+   cd ~/flexiv_ros2_ws/src/flexiv_rdk/thirdparty
    bash build_and_install_dependencies.sh ~/rdk_install
    ```
 
 6. Configure and install `flexiv_rdk`:
 
    ```bash
-   cd ~/flexiv_ros2_ws/src/flexiv_ros2/flexiv_hardware/rdk
+   cd ~/flexiv_ros2_ws/src/flexiv_rdk
    mkdir build && cd build
    cmake .. -DCMAKE_INSTALL_PREFIX=~/rdk_install
    cmake --build . --target install --config Release
@@ -118,7 +116,7 @@ The main launch file to start the robot driver is the `rizon.launch.py` - it loa
 - `rdk_control_mode` (default: *joint_position*) - Flexiv RDK control mode for ROS 2 joint position and velocity interfaces. Options: *joint_position* or *joint_impedance*
 - `load_gripper` (default: *false*) - loads the Flexiv Grav gripper as the end-effector of the robot and the gripper control node.
 - `use_fake_hardware` (default: *false*) - starts `FakeSystem` instead of real hardware. This is a simple simulation that mimics joint command to their states.
-- `start_rviz` (deafult: *true*) - starts RViz automatically with the launch file.
+- `start_rviz` (default: *true*) - starts RViz automatically with the launch file.
 - `fake_sensor_commands` (default: *false*) - enables fake command interfaces for sensors used for simulations. Used only if `use_fake_hardware` parameter is true.
 - `robot_controller` (default: *rizon_arm_controller*) - robot controller to start. Available controllers: *rizon_arm_controller*
 

--- a/flexiv.humble.repos
+++ b/flexiv.humble.repos
@@ -3,3 +3,7 @@ repositories:
     type: git
     url: https://github.com/flexivrobotics/flexiv_description.git
     version: humble
+  flexiv_rdk:
+    type: git
+    url: https://github.com/flexivrobotics/flexiv_rdk.git
+    version: v1.8

--- a/flexiv.humble.repos
+++ b/flexiv.humble.repos
@@ -6,4 +6,4 @@ repositories:
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git
-    version: v1.8
+    version: release/v1.9

--- a/flexiv_bringup/config/rizon_dual_controllers.yaml
+++ b/flexiv_bringup/config/rizon_dual_controllers.yaml
@@ -2,10 +2,10 @@ controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
 
-    left_arm_controller:
+    left_rizon_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-    right_arm_controller:
+    right_rizon_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
     joint_state_broadcaster:
@@ -23,7 +23,7 @@ controller_manager:
     flexiv_robot_states_broadcaster_right:
       type: flexiv_robot_states_broadcaster/FlexivRobotStatesBroadcaster
 
-left_arm_controller:
+left_rizon_arm_controller:
   ros__parameters:
     joints:
       - $(var prefix_left)joint1
@@ -45,7 +45,7 @@ left_arm_controller:
       stopped_velocity_tolerance: 0.01
       goal_time: 0.0
 
-right_arm_controller:
+right_rizon_arm_controller:
   ros__parameters:
     joints:
       - $(var prefix_right)joint1

--- a/flexiv_bringup/config/rizon_dual_controllers.yaml
+++ b/flexiv_bringup/config/rizon_dual_controllers.yaml
@@ -1,0 +1,65 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 1000  # Hz
+
+    left_arm_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    right_arm_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    gpio_controller:
+      type: gpio_controller/GPIOController
+
+    flexiv_robot_states_broadcaster_left:
+      type: flexiv_robot_states_broadcaster/FlexivRobotStatesBroadcaster
+
+    flexiv_robot_states_broadcaster_right:
+      type: flexiv_robot_states_broadcaster/FlexivRobotStatesBroadcaster
+
+left_arm_controller:
+  ros__parameters:
+    joints:
+      - $(var prefix_left)joint1
+      - $(var prefix_left)joint2
+      - $(var prefix_left)joint3
+      - $(var prefix_left)joint4
+      - $(var prefix_left)joint5
+      - $(var prefix_left)joint6
+      - $(var prefix_left)joint7
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.01
+      goal_time: 0.0
+
+right_arm_controller:
+  ros__parameters:
+    joints:
+      - $(var prefix_right)joint1
+      - $(var prefix_right)joint2
+      - $(var prefix_right)joint3
+      - $(var prefix_right)joint4
+      - $(var prefix_right)joint5
+      - $(var prefix_right)joint6
+      - $(var prefix_right)joint7
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.01
+      goal_time: 0.0

--- a/flexiv_bringup/config/rizon_dual_controllers.yaml
+++ b/flexiv_bringup/config/rizon_dual_controllers.yaml
@@ -11,7 +11,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    gpio_controller:
+    gpio_controller_left:
+      type: gpio_controller/GPIOController
+
+    gpio_controller_right:
       type: gpio_controller/GPIOController
 
     flexiv_robot_states_broadcaster_left:
@@ -63,3 +66,19 @@ right_arm_controller:
     constraints:
       stopped_velocity_tolerance: 0.01
       goal_time: 0.0
+
+flexiv_robot_states_broadcaster_left:
+  ros__parameters:
+    robot_sn: left_$(var robot_sn_left)
+
+flexiv_robot_states_broadcaster_right:
+  ros__parameters:
+    robot_sn: right_$(var robot_sn_right)
+
+gpio_controller_left:
+  ros__parameters:
+    robot_sn: left_$(var robot_sn_left)
+
+gpio_controller_right:
+  ros__parameters:
+    robot_sn: right_$(var robot_sn_right)

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -315,22 +315,22 @@ def generate_launch_description():
     )
 
     # Run left arm controller
-    left_arm_controller_spawner = Node(
+    left_rizon_arm_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=[
-            "left_arm_controller",
+            "left_rizon_arm_controller",
             "--controller-manager",
             "/controller_manager",
         ],
     )
 
     # Run right arm controller
-    right_arm_controller_spawner = Node(
+    right_rizon_arm_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=[
-            "right_arm_controller",
+            "right_rizon_arm_controller",
             "--controller-manager",
             "/controller_manager",
         ],
@@ -416,22 +416,22 @@ def generate_launch_description():
     delay_left_controller_after_jsb = RegisterEventHandler(
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
-            on_exit=[left_arm_controller_spawner],
+            on_exit=[left_rizon_arm_controller_spawner],
         )
     )
 
     # Delay right controller start after left controller
     delay_right_controller_after_left_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=left_arm_controller_spawner,
-            on_exit=[right_arm_controller_spawner],
+            target_action=left_rizon_arm_controller_spawner,
+            on_exit=[right_rizon_arm_controller_spawner],
         )
     )
 
     # Delay rviz start after right controller
     delay_rviz_after_right_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=right_arm_controller_spawner,
+            target_action=right_rizon_arm_controller_spawner,
             on_exit=[rviz_node],
         )
     )

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -3,7 +3,6 @@ from launch.actions import (
     DeclareLaunchArgument,
     IncludeLaunchDescription,
     RegisterEventHandler,
-    SetLaunchConfiguration,
 )
 from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit
@@ -29,6 +28,12 @@ def generate_launch_description():
     start_rviz_param_name = "start_rviz"
     use_fake_hardware_param_name = "use_fake_hardware"
     fake_sensor_commands_param_name = "fake_sensor_commands"
+    load_gripper_left_param_name = "load_gripper_left"
+    gripper_name_left_param_name = "gripper_name_left"
+    load_gripper_right_param_name = "load_gripper_right"
+    gripper_name_right_param_name = "gripper_name_right"
+    load_mounted_ft_sensor_left_param_name = "load_mounted_ft_sensor_left"
+    load_mounted_ft_sensor_right_param_name = "load_mounted_ft_sensor_right"
 
     # Declare arguments
     declared_arguments = []
@@ -98,6 +103,54 @@ def generate_launch_description():
         )
     )
 
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            load_gripper_left_param_name,
+            default_value="false",
+            description="Flag to load the Flexiv Grav gripper as the end-effector of the left robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            gripper_name_left_param_name,
+            default_value="Flexiv-GN01",
+            description="Full name of the left gripper to be controlled, can be found in Flexiv Elements -> Settings -> Device",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            load_gripper_right_param_name,
+            default_value="false",
+            description="Flag to load the Flexiv Grav gripper as the end-effector of the right robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            gripper_name_right_param_name,
+            default_value="Flexiv-GN01",
+            description="Full name of the right gripper to be controlled, can be found in Flexiv Elements -> Settings -> Device",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            load_mounted_ft_sensor_left_param_name,
+            default_value="false",
+            description="Flag to load the mounted force torque sensor for the left robot. Only available for Rizon4, Rizon4R and Rizon10.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            load_mounted_ft_sensor_right_param_name,
+            default_value="false",
+            description="Flag to load the mounted force torque sensor for the right robot. Only available for Rizon4, Rizon4R and Rizon10.",
+        )
+    )
+
     # Initialize Arguments
     rizon_type_left = LaunchConfiguration(rizon_type_left_param_name)
     rizon_type_right = LaunchConfiguration(rizon_type_right_param_name)
@@ -107,6 +160,16 @@ def generate_launch_description():
     start_rviz = LaunchConfiguration(start_rviz_param_name)
     use_fake_hardware = LaunchConfiguration(use_fake_hardware_param_name)
     fake_sensor_commands = LaunchConfiguration(fake_sensor_commands_param_name)
+    load_gripper_left = LaunchConfiguration(load_gripper_left_param_name)
+    gripper_name_left = LaunchConfiguration(gripper_name_left_param_name)
+    load_gripper_right = LaunchConfiguration(load_gripper_right_param_name)
+    gripper_name_right = LaunchConfiguration(gripper_name_right_param_name)
+    load_mounted_ft_sensor_left = LaunchConfiguration(
+        load_mounted_ft_sensor_left_param_name
+    )
+    load_mounted_ft_sensor_right = LaunchConfiguration(
+        load_mounted_ft_sensor_right_param_name
+    )
 
     # Construct prefixes
     from launch.actions import SetLaunchConfiguration
@@ -119,8 +182,6 @@ def generate_launch_description():
         name="prefix_right",
         value=PythonExpression(["'right_' + '", robot_sn_right, "' + '_'"]),
     )
-
-    # Get URDF via xacro
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
@@ -145,6 +206,24 @@ def generate_launch_description():
                 " ",
                 "rizon_type_right:=",
                 rizon_type_right,
+                " ",
+                "load_gripper_left:=",
+                load_gripper_left,
+                " ",
+                "gripper_name_left:=",
+                gripper_name_left,
+                " ",
+                "load_gripper_right:=",
+                load_gripper_right,
+                " ",
+                "gripper_name_right:=",
+                gripper_name_right,
+                " ",
+                "load_mounted_ft_sensor_left:=",
+                load_mounted_ft_sensor_left,
+                " ",
+                "load_mounted_ft_sensor_right:=",
+                load_mounted_ft_sensor_right,
                 " ",
                 "ros2_control:=true ",
                 "rdk_control_mode:=",
@@ -194,6 +273,7 @@ def generate_launch_description():
             {"prefix_right": LaunchConfiguration("prefix_right")},
             {"rdk_control_mode": rdk_control_mode},
         ],
+        remappings=[("joint_states", "flexiv_dual_arm/joint_states")],
         output="both",
     )
 
@@ -205,9 +285,9 @@ def generate_launch_description():
         parameters=[
             {
                 "source_list": [
-                    "left_arm_controller/joint_states",
-                    "right_arm_controller/joint_states",
-                    "joint_states",
+                    "flexiv_dual_arm/joint_states",
+                    "left_gripper_node/gripper_joint_states",
+                    "right_gripper_node/gripper_joint_states",
                 ],
                 "rate": 30,
             }
@@ -261,7 +341,6 @@ def generate_launch_description():
         package="controller_manager",
         executable="spawner",
         arguments=["flexiv_robot_states_broadcaster_left"],
-        parameters=[{"robot_sn": robot_sn_left}],
         condition=UnlessCondition(use_fake_hardware),
     )
 
@@ -270,15 +349,66 @@ def generate_launch_description():
         package="controller_manager",
         executable="spawner",
         arguments=["flexiv_robot_states_broadcaster_right"],
-        parameters=[{"robot_sn": robot_sn_right}],
         condition=UnlessCondition(use_fake_hardware),
     )
 
-    # Run gpio controller
-    gpio_controller_spawner = Node(
+    # Include gripper launch files
+    load_gripper_left_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("flexiv_gripper"),
+                    "launch",
+                    "flexiv_gripper.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "gripper_node_name": "left_gripper_node",
+            "robot_sn": robot_sn_left,
+            "gripper_name": gripper_name_left,
+            "use_fake_hardware": use_fake_hardware,
+        }.items(),
+        condition=IfCondition(load_gripper_left),
+    )
+    load_gripper_right_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("flexiv_gripper"),
+                    "launch",
+                    "flexiv_gripper.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "gripper_node_name": "right_gripper_node",
+            "robot_sn": robot_sn_right,
+            "gripper_name": gripper_name_right,
+            "use_fake_hardware": use_fake_hardware,
+        }.items(),
+        condition=IfCondition(load_gripper_right),
+    )
+
+    # Run gpio controllers
+    gpio_controller_left_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["gpio_controller", "--controller-manager", "/controller_manager"],
+        arguments=[
+            "gpio_controller_left",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+    gpio_controller_right_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "gpio_controller_right",
+            "--controller-manager",
+            "/controller_manager",
+        ],
         condition=UnlessCondition(use_fake_hardware),
     )
 
@@ -290,17 +420,18 @@ def generate_launch_description():
         )
     )
 
-    delay_right_controller_after_jsb = RegisterEventHandler(
+    # Delay right controller start after left controller
+    delay_right_controller_after_left_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
+            target_action=left_arm_controller_spawner,
             on_exit=[right_arm_controller_spawner],
         )
     )
 
-    # Delay rviz start after `joint_state_broadcaster` (just to be safe)
-    delay_rviz_after_jsb = RegisterEventHandler(
+    # Delay rviz start after right controller
+    delay_rviz_after_right_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
+            target_action=right_arm_controller_spawner,
             on_exit=[rviz_node],
         )
     )
@@ -314,10 +445,13 @@ def generate_launch_description():
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_left_spawner,
         flexiv_robot_states_broadcaster_right_spawner,
-        gpio_controller_spawner,
+        load_gripper_left_launch,
+        load_gripper_right_launch,
+        gpio_controller_left_spawner,
+        gpio_controller_right_spawner,
         delay_left_controller_after_jsb,
-        delay_right_controller_after_jsb,
-        delay_rviz_after_jsb,
+        delay_right_controller_after_left_controller,
+        delay_rviz_after_right_controller,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -1,0 +1,323 @@
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    RegisterEventHandler,
+    SetLaunchConfiguration,
+)
+from launch.conditions import IfCondition, UnlessCondition
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
+
+
+def generate_launch_description():
+    rizon_type_left_param_name = "rizon_type_left"
+    rizon_type_right_param_name = "rizon_type_right"
+    robot_sn_left_param_name = "robot_sn_left"
+    robot_sn_right_param_name = "robot_sn_right"
+    rdk_control_mode_param_name = "rdk_control_mode"
+    start_rviz_param_name = "start_rviz"
+    use_fake_hardware_param_name = "use_fake_hardware"
+    fake_sensor_commands_param_name = "fake_sensor_commands"
+
+    # Declare arguments
+    declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            rizon_type_left_param_name,
+            description="Type of the left Flexiv Rizon robot.",
+            default_value="Rizon4",
+            choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            rizon_type_right_param_name,
+            description="Type of the right Flexiv Rizon robot.",
+            default_value="Rizon4",
+            choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            robot_sn_left_param_name,
+            description="Serial number of the left robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            robot_sn_right_param_name,
+            description="Serial number of the right robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            rdk_control_mode_param_name,
+            default_value="joint_position",
+            description="RDK control mode for the ROS 2 control joint position and velocity interfaces.",
+            choices=["joint_position", "joint_impedance"],
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            start_rviz_param_name,
+            default_value="true",
+            description="Start RViz automatically with the launch file",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            use_fake_hardware_param_name,
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            fake_sensor_commands_param_name,
+            default_value="false",
+            description="Enable fake command interfaces for sensors used for simple simulations.",
+        )
+    )
+
+    # Initialize Arguments
+    rizon_type_left = LaunchConfiguration(rizon_type_left_param_name)
+    rizon_type_right = LaunchConfiguration(rizon_type_right_param_name)
+    robot_sn_left = LaunchConfiguration(robot_sn_left_param_name)
+    robot_sn_right = LaunchConfiguration(robot_sn_right_param_name)
+    rdk_control_mode = LaunchConfiguration(rdk_control_mode_param_name)
+    start_rviz = LaunchConfiguration(start_rviz_param_name)
+    use_fake_hardware = LaunchConfiguration(use_fake_hardware_param_name)
+    fake_sensor_commands = LaunchConfiguration(fake_sensor_commands_param_name)
+
+    # Construct prefixes
+    from launch.actions import SetLaunchConfiguration
+
+    set_prefix_left = SetLaunchConfiguration(
+        name="prefix_left",
+        value=PythonExpression(["'left_' + '", robot_sn_left, "' + '_'"]),
+    )
+    set_prefix_right = SetLaunchConfiguration(
+        name="prefix_right",
+        value=PythonExpression(["'right_' + '", robot_sn_right, "' + '_'"]),
+    )
+
+    # Get URDF via xacro
+
+    # Get URDF via xacro
+    flexiv_urdf_xacro = PathJoinSubstitution(
+        [FindPackageShare("flexiv_description"), "urdf", "rizon_dual.urdf.xacro"]
+    )
+
+    robot_description_content = ParameterValue(
+        Command(
+            [
+                PathJoinSubstitution([FindExecutable(name="xacro")]),
+                " ",
+                flexiv_urdf_xacro,
+                " ",
+                "robot_sn_left:=",
+                robot_sn_left,
+                " ",
+                "robot_sn_right:=",
+                robot_sn_right,
+                " ",
+                "rizon_type_left:=",
+                rizon_type_left,
+                " ",
+                "rizon_type_right:=",
+                rizon_type_right,
+                " ",
+                "ros2_control:=true ",
+                "rdk_control_mode:=",
+                rdk_control_mode,
+                " ",
+                "use_fake_hardware:=",
+                use_fake_hardware,
+                " ",
+                "fake_sensor_commands:=",
+                fake_sensor_commands,
+            ]
+        ),
+        value_type=str,
+    )
+
+    robot_description = {"robot_description": robot_description_content}
+
+    # RViZ
+    rviz_config_file = PathJoinSubstitution(
+        [FindPackageShare("flexiv_description"), "rviz", "view_rizon.rviz"]
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        condition=IfCondition(start_rviz),
+    )
+
+    # Robot controllers
+    robot_controllers = PathJoinSubstitution(
+        [FindPackageShare("flexiv_bringup"), "config", "rizon_dual_controllers.yaml"]
+    )
+
+    # Controller Manager
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            robot_description,
+            ParameterFile(robot_controllers, allow_substs=True),
+            {"robot_sn_left": robot_sn_left},
+            {"robot_sn_right": robot_sn_right},
+            {"prefix_left": LaunchConfiguration("prefix_left")},
+            {"prefix_right": LaunchConfiguration("prefix_right")},
+            {"rdk_control_mode": rdk_control_mode},
+        ],
+        output="both",
+    )
+
+    # Joint state publisher
+    joint_state_publisher_node = Node(
+        package="joint_state_publisher",
+        executable="joint_state_publisher",
+        name="joint_state_publisher",
+        parameters=[
+            {
+                "source_list": [
+                    "left_arm_controller/joint_states",
+                    "right_arm_controller/joint_states",
+                    "joint_states",
+                ],
+                "rate": 30,
+            }
+        ],
+    )
+
+    # Robot state publisher
+    robot_state_publisher_node = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
+
+    # Run joint state broadcaster
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    # Run left arm controller
+    left_arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "left_arm_controller",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    # Run right arm controller
+    right_arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "right_arm_controller",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    # Run Flexiv robot states broadcaster left
+    flexiv_robot_states_broadcaster_left_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["flexiv_robot_states_broadcaster_left"],
+        parameters=[{"robot_sn": robot_sn_left}],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+
+    # Run Flexiv robot states broadcaster right
+    flexiv_robot_states_broadcaster_right_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["flexiv_robot_states_broadcaster_right"],
+        parameters=[{"robot_sn": robot_sn_right}],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+
+    # Run gpio controller
+    gpio_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["gpio_controller", "--controller-manager", "/controller_manager"],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+
+    # Delay start of controllers after `joint_state_broadcaster`
+    delay_left_controller_after_jsb = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[left_arm_controller_spawner],
+        )
+    )
+
+    delay_right_controller_after_jsb = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[right_arm_controller_spawner],
+        )
+    )
+
+    # Delay rviz start after `joint_state_broadcaster` (just to be safe)
+    delay_rviz_after_jsb = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[rviz_node],
+        )
+    )
+
+    nodes = [
+        set_prefix_left,
+        set_prefix_right,
+        ros2_control_node,
+        joint_state_publisher_node,
+        robot_state_publisher_node,
+        joint_state_broadcaster_spawner,
+        flexiv_robot_states_broadcaster_left_spawner,
+        flexiv_robot_states_broadcaster_right_spawner,
+        gpio_controller_spawner,
+        delay_left_controller_after_jsb,
+        delay_right_controller_after_jsb,
+        delay_rviz_after_jsb,
+    ]
+
+    return LaunchDescription(declared_arguments + nodes)

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             rizon_type_right_param_name,
             description="Type of the right Flexiv Rizon robot.",
-            default_value="Rizon4",
+            default_value="Rizon4R",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )
     )

--- a/flexiv_bringup/launch/rizon_dual_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_dual_moveit.launch.py
@@ -1,0 +1,636 @@
+import os
+import yaml
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+    RegisterEventHandler,
+    SetLaunchConfiguration,
+)
+from launch.conditions import IfCondition, UnlessCondition
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+
+
+def load_yaml(package_name, file_path, replacements=None):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, "r") as file:
+            yaml_content = file.read()
+
+        if replacements:
+            for key, value in replacements.items():
+                yaml_content = yaml_content.replace(key, value)
+
+        return yaml.safe_load(yaml_content)
+    except (
+        EnvironmentError
+    ):  # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def launch_setup(context):
+    # Initialize Arguments
+    rizon_type_left = LaunchConfiguration("rizon_type_left")
+    rizon_type_right = LaunchConfiguration("rizon_type_right")
+    robot_sn_left = LaunchConfiguration("robot_sn_left")
+    robot_sn_right = LaunchConfiguration("robot_sn_right")
+
+    robot_sn_left_str = robot_sn_left.perform(context)
+    robot_sn_right_str = robot_sn_right.perform(context)
+
+    rdk_control_mode = LaunchConfiguration("rdk_control_mode")
+    start_rviz = LaunchConfiguration("start_rviz")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+
+    load_gripper_left = LaunchConfiguration("load_gripper_left")
+    gripper_name_left = LaunchConfiguration("gripper_name_left")
+    load_gripper_right = LaunchConfiguration("load_gripper_right")
+    gripper_name_right = LaunchConfiguration("gripper_name_right")
+
+    load_mounted_ft_sensor_left = LaunchConfiguration("load_mounted_ft_sensor_left")
+    load_mounted_ft_sensor_right = LaunchConfiguration("load_mounted_ft_sensor_right")
+
+    warehouse_sqlite_path = LaunchConfiguration("warehouse_sqlite_path")
+
+    # Construct prefixes
+    prefix_left_str = "left_" + robot_sn_left_str + "_"
+    prefix_right_str = "right_" + robot_sn_right_str + "_"
+
+    set_prefix_left = SetLaunchConfiguration(name="prefix_left", value=prefix_left_str)
+    set_prefix_right = SetLaunchConfiguration(
+        name="prefix_right", value=prefix_right_str
+    )
+
+    # Get URDF via xacro
+    flexiv_urdf_xacro = PathJoinSubstitution(
+        [FindPackageShare("flexiv_description"), "urdf", "rizon_dual.urdf.xacro"]
+    )
+
+    robot_description_content = ParameterValue(
+        Command(
+            [
+                PathJoinSubstitution([FindExecutable(name="xacro")]),
+                " ",
+                flexiv_urdf_xacro,
+                " ",
+                "robot_sn_left:=",
+                robot_sn_left,
+                " ",
+                "robot_sn_right:=",
+                robot_sn_right,
+                " ",
+                "rizon_type_left:=",
+                rizon_type_left,
+                " ",
+                "rizon_type_right:=",
+                rizon_type_right,
+                " ",
+                "load_gripper_left:=",
+                load_gripper_left,
+                " ",
+                "gripper_name_left:=",
+                gripper_name_left,
+                " ",
+                "load_gripper_right:=",
+                load_gripper_right,
+                " ",
+                "gripper_name_right:=",
+                gripper_name_right,
+                " ",
+                "load_mounted_ft_sensor_left:=",
+                load_mounted_ft_sensor_left,
+                " ",
+                "load_mounted_ft_sensor_right:=",
+                load_mounted_ft_sensor_right,
+                " ",
+                "ros2_control:=true ",
+                "rdk_control_mode:=",
+                rdk_control_mode,
+                " ",
+                "use_fake_hardware:=",
+                use_fake_hardware,
+                " ",
+                "fake_sensor_commands:=",
+                fake_sensor_commands,
+            ]
+        ),
+        value_type=str,
+    )
+
+    robot_description = {"robot_description": robot_description_content}
+
+    # MoveIt configuration
+    flexiv_srdf_xacro = PathJoinSubstitution(
+        [FindPackageShare("flexiv_moveit_config"), "srdf", "rizon_dual.srdf.xacro"]
+    )
+
+    robot_description_semantic_content = ParameterValue(
+        Command(
+            [
+                PathJoinSubstitution([FindExecutable(name="xacro")]),
+                " ",
+                flexiv_srdf_xacro,
+                " ",
+                "robot_sn_left:=",
+                robot_sn_left,
+                " ",
+                "robot_sn_right:=",
+                robot_sn_right,
+                " ",
+                "load_gripper_left:=",
+                load_gripper_left,
+                " ",
+                "load_gripper_right:=",
+                load_gripper_right,
+                " ",
+                "load_mounted_ft_sensor_left:=",
+                load_mounted_ft_sensor_left,
+                " ",
+                "load_mounted_ft_sensor_right:=",
+                load_mounted_ft_sensor_right,
+                " ",
+                "prefix_left:=",
+                "left_",
+                " ",
+                "prefix_right:=",
+                "right_",
+            ]
+        ),
+        value_type=str,
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_content
+    }
+
+    publish_robot_description_semantic = {"publish_robot_description_semantic": True}
+
+    # Trajectory Execution Configuration
+    replacements = {
+        "$(var prefix_left)": prefix_left_str,
+        "$(var prefix_right)": prefix_right_str,
+    }
+
+    robot_description_kinematics_yaml = load_yaml(
+        "flexiv_moveit_config", "config/dual_arm/kinematics_dual.yaml", replacements
+    )
+    robot_description_kinematics = {
+        "robot_description_kinematics": robot_description_kinematics_yaml
+    }
+
+    # Planning Configuration
+    ompl_planning_pipeline_config = {
+        "move_group": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": "default_planner_request_adapters/AddTimeOptimalParameterization "
+            "default_planner_request_adapters/ResolveConstraintFrames "
+            "default_planner_request_adapters/FixWorkspaceBounds "
+            "default_planner_request_adapters/FixStartStateBounds "
+            "default_planner_request_adapters/FixStartStateCollision "
+            "default_planner_request_adapters/FixStartStatePathConstraints",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    ompl_planning_yaml = load_yaml(
+        "flexiv_moveit_config", "config/dual_arm/ompl_planning_dual.yaml", replacements
+    )
+    ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
+
+    moveit_simple_controllers_yaml = load_yaml(
+        "flexiv_moveit_config",
+        "config/dual_arm/moveit_controllers_dual.yaml",
+        replacements,
+    )
+
+    moveit_controllers = {
+        "moveit_simple_controller_manager": moveit_simple_controllers_yaml,
+        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
+    }
+
+    trajectory_execution = {
+        "moveit_manage_controllers": False,
+        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
+        "trajectory_execution.allowed_goal_duration_margin": 0.5,
+        "trajectory_execution.allowed_start_tolerance": 0.01,
+    }
+
+    planning_scene_monitor_parameters = {
+        "publish_planning_scene": True,
+        "publish_geometry_updates": True,
+        "publish_state_updates": True,
+        "publish_transforms_updates": True,
+    }
+
+    # Load for left arm
+    joint_limits_left = load_yaml(
+        "flexiv_moveit_config",
+        "config/joint_limits.yaml",
+        {"$(var robot_sn)": prefix_left_str.rstrip("_")},
+    )
+    joint_limits_right = load_yaml(
+        "flexiv_moveit_config",
+        "config/joint_limits.yaml",
+        {"$(var robot_sn)": prefix_right_str.rstrip("_")},
+    )
+
+    joint_limits_yaml = {"robot_description_planning": {"joint_limits": {}}}
+
+    if joint_limits_left and "joint_limits" in joint_limits_left:
+        joint_limits_yaml["robot_description_planning"]["joint_limits"].update(
+            joint_limits_left["joint_limits"]
+        )
+
+    if joint_limits_right and "joint_limits" in joint_limits_right:
+        joint_limits_yaml["robot_description_planning"]["joint_limits"].update(
+            joint_limits_right["joint_limits"]
+        )
+
+    warehouse_ros_config = {
+        "warehouse_plugin": "warehouse_ros_sqlite::DatabaseConnection",
+        "warehouse_host": warehouse_sqlite_path,
+    }
+
+    # Start the actual move_group node/action server
+    move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            publish_robot_description_semantic,
+            robot_description_kinematics,
+            joint_limits_yaml,
+            ompl_planning_pipeline_config,
+            trajectory_execution,
+            moveit_controllers,
+            planning_scene_monitor_parameters,
+            warehouse_ros_config,
+        ],
+    )
+
+    # RViz with MoveIt configuration
+    rviz_config_file = PathJoinSubstitution(
+        [FindPackageShare("flexiv_moveit_config"), "rviz", "moveit.rviz"]
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2_moveit",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            ompl_planning_pipeline_config,
+            robot_description_kinematics,
+            joint_limits_yaml,
+            warehouse_ros_config,
+        ],
+        condition=IfCondition(start_rviz),
+    )
+
+    # Publish TF
+    robot_state_publisher_node = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
+
+    # Robot controllers
+    robot_controllers = PathJoinSubstitution(
+        [FindPackageShare("flexiv_bringup"), "config", "rizon_dual_controllers.yaml"]
+    )
+
+    # Run controller manager
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            robot_description,
+            ParameterFile(robot_controllers, allow_substs=True),
+            {"robot_sn_left": robot_sn_left},
+            {"robot_sn_right": robot_sn_right},
+            {"prefix_left": prefix_left_str},
+            {"prefix_right": prefix_right_str},
+            {"rdk_control_mode": rdk_control_mode},
+        ],
+        remappings=[("joint_states", "flexiv_dual_arm/joint_states")],
+        output="both",
+    )
+
+    # Joint state publisher
+    joint_state_publisher_node = Node(
+        package="joint_state_publisher",
+        executable="joint_state_publisher",
+        name="joint_state_publisher",
+        parameters=[
+            {
+                "source_list": [
+                    "flexiv_dual_arm/joint_states",
+                    "left_gripper_node/gripper_joint_states",
+                    "right_gripper_node/gripper_joint_states",
+                ],
+                "rate": 30,
+            }
+        ],
+    )
+
+    # Run robot controller
+    left_rizon_arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "left_rizon_arm_controller",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    right_rizon_arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "right_rizon_arm_controller",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    # Run joint state broadcaster
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    # Run Flexiv robot states broadcaster
+    flexiv_robot_states_broadcaster_left_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["flexiv_robot_states_broadcaster_left"],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+
+    flexiv_robot_states_broadcaster_right_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["flexiv_robot_states_broadcaster_right"],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+
+    load_gripper_left_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("flexiv_gripper"),
+                    "launch",
+                    "flexiv_gripper.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "robot_sn": robot_sn_left,
+            "gripper_name": gripper_name_left,
+            "use_fake_hardware": use_fake_hardware,
+            "gripper_node_name": "left_gripper_node",
+        }.items(),
+        condition=IfCondition(load_gripper_left),
+    )
+
+    load_gripper_right_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("flexiv_gripper"),
+                    "launch",
+                    "flexiv_gripper.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "robot_sn": robot_sn_right,
+            "gripper_name": gripper_name_right,
+            "use_fake_hardware": use_fake_hardware,
+            "gripper_node_name": "right_gripper_node",
+        }.items(),
+        condition=IfCondition(load_gripper_right),
+    )
+
+    # Run gpio controllers
+    gpio_controller_left_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "gpio_controller_left",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+    gpio_controller_right_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "gpio_controller_right",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+        condition=UnlessCondition(use_fake_hardware),
+    )
+
+    # Delay start of controllers after `joint_state_broadcaster`
+    delay_left_controller_after_jsb = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[left_rizon_arm_controller_spawner],
+        )
+    )
+
+    # Delay right controller start after left controller
+    delay_right_controller_after_left_controller = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_rizon_arm_controller_spawner,
+            on_exit=[right_rizon_arm_controller_spawner],
+        )
+    )
+
+    # Delay rviz start after right controller
+    delay_rviz_after_right_controller = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=right_rizon_arm_controller_spawner,
+            on_exit=[rviz_node],
+        )
+    )
+
+    nodes = [
+        set_prefix_left,
+        set_prefix_right,
+        move_group_node,
+        robot_state_publisher_node,
+        ros2_control_node,
+        joint_state_publisher_node,
+        joint_state_broadcaster_spawner,
+        flexiv_robot_states_broadcaster_left_spawner,
+        flexiv_robot_states_broadcaster_right_spawner,
+        load_gripper_left_launch,
+        load_gripper_right_launch,
+        gpio_controller_left_spawner,
+        gpio_controller_right_spawner,
+        delay_left_controller_after_jsb,
+        delay_right_controller_after_left_controller,
+        delay_rviz_after_right_controller,
+    ]
+
+    return nodes
+
+
+def generate_launch_description():
+    declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "rizon_type_left",
+            description="Type of the left Flexiv Rizon robot.",
+            default_value="Rizon4",
+            choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "rizon_type_right",
+            description="Type of the right Flexiv Rizon robot.",
+            default_value="Rizon4R",
+            choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_sn_left",
+            description="Serial number of the left robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_sn_right",
+            description="Serial number of the right robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "rdk_control_mode",
+            default_value="joint_position",
+            description="RDK control mode for the ROS 2 control joint position and velocity interfaces.",
+            choices=["joint_position", "joint_impedance"],
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "start_rviz",
+            default_value="true",
+            description="Start RViz automatically with the launch file",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "fake_sensor_commands",
+            default_value="false",
+            description="Enable fake command interfaces for sensors used for simple simulations.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "load_gripper_left",
+            default_value="false",
+            description="Flag to load the Flexiv Grav gripper as the end-effector of the left robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "gripper_name_left",
+            default_value="Flexiv-GN01",
+            description="Full name of the left gripper to be controlled, can be found in Flexiv Elements -> Settings -> Device",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "load_gripper_right",
+            default_value="false",
+            description="Flag to load the Flexiv Grav gripper as the end-effector of the right robot.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "gripper_name_right",
+            default_value="Flexiv-GN01",
+            description="Full name of the right gripper to be controlled, can be found in Flexiv Elements -> Settings -> Device",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "load_mounted_ft_sensor_left",
+            default_value="false",
+            description="Flag to load the mounted force torque sensor for the left robot. Only available for Rizon4, Rizon4R and Rizon10.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "load_mounted_ft_sensor_right",
+            default_value="false",
+            description="Flag to load the mounted force torque sensor for the right robot. Only available for Rizon4, Rizon4R and Rizon10.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "warehouse_sqlite_path",
+            default_value=os.path.expanduser("~/.ros/warehouse_ros.sqlite"),
+            description="Path to the warehouse database",
+        )
+    )
+
+    return LaunchDescription(
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/flexiv_gripper/config/flexiv_gripper_node.yaml
+++ b/flexiv_gripper/config/flexiv_gripper_node.yaml
@@ -1,4 +1,4 @@
-flexiv_gripper:
+/**:
   ros__parameters:
     state_publish_rate: 50 # Hz
     feedback_publish_rate: 30 # Hz

--- a/flexiv_gripper/launch/flexiv_gripper.launch.py
+++ b/flexiv_gripper/launch/flexiv_gripper.launch.py
@@ -10,6 +10,7 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    gripper_node_param_name = "gripper_node_name"
     robot_sn_param_name = "robot_sn"
     gripper_name_param_name = "gripper_name"
     use_fake_hardware_param_name = "use_fake_hardware"
@@ -17,6 +18,14 @@ def generate_launch_description():
 
     # Declare arguments
     declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            gripper_node_param_name,
+            default_value="flexiv_gripper_node",
+            description="Name of the flexiv gripper node.",
+        )
+    )
 
     declared_arguments.append(
         DeclareLaunchArgument(
@@ -50,6 +59,7 @@ def generate_launch_description():
     )
 
     # Initialize arguments
+    gripper_node = LaunchConfiguration(gripper_node_param_name)
     robot_sn = LaunchConfiguration(robot_sn_param_name)
     gripper_name = LaunchConfiguration(gripper_name_param_name)
     use_fake_hardware = LaunchConfiguration(use_fake_hardware_param_name)
@@ -63,7 +73,7 @@ def generate_launch_description():
     flexiv_gripper_node = Node(
         package="flexiv_gripper",
         executable="flexiv_gripper_node",
-        name="flexiv_gripper_node",
+        name=gripper_node,
         parameters=[
             {
                 "robot_sn": robot_sn,

--- a/flexiv_hardware/CMakeLists.txt
+++ b/flexiv_hardware/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(flexiv_rdk REQUIRED)
+find_package(flexiv_drdk QUIET)
 
 add_library(
   ${PROJECT_NAME}
@@ -34,6 +35,14 @@ target_include_directories(
 target_link_libraries(${PROJECT_NAME}
   flexiv::flexiv_rdk
 )
+
+if(flexiv_drdk_FOUND)
+  target_link_libraries(${PROJECT_NAME}
+    flexiv::flexiv_drdk
+  )
+  target_compile_definitions(${PROJECT_NAME} PRIVATE FLEXIV_DRDK_AVAILABLE)
+  message(STATUS "Flexiv DRDK library found and linked.")
+endif()
 
 # Link ROS packages
 ament_target_dependencies(

--- a/flexiv_hardware/CMakeLists.txt
+++ b/flexiv_hardware/CMakeLists.txt
@@ -26,6 +26,10 @@ add_library(
   src/flexiv_hardware_interface.cpp
 )
 
+if(flexiv_drdk_FOUND)
+  target_sources(${PROJECT_NAME} PRIVATE src/flexiv_dual_hardware_interface.cpp)
+endif()
+
 target_include_directories(
   ${PROJECT_NAME}
   PRIVATE

--- a/flexiv_hardware/CMakeLists.txt
+++ b/flexiv_hardware/CMakeLists.txt
@@ -29,7 +29,6 @@ target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/rdk/include
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/flexiv_hardware/flexiv_hardware_interface_plugin.xml
+++ b/flexiv_hardware/flexiv_hardware_interface_plugin.xml
@@ -8,4 +8,13 @@
             uses Flexiv RDK. Position, Velocity and Effort interfaces are supported.
         </description>
     </class>
+    <class name="flexiv_hardware/FlexivDualHardwareInterface"
+           type="flexiv_hardware::FlexivDualHardwareInterface"
+           base_class_type="hardware_interface::SystemInterface">
+
+        <description>
+            ROS 2 Control Hardware interface for a pair of Flexiv robots. This driver
+            uses Flexiv DRDK. Position, Velocity and Effort interfaces are supported.
+        </description>
+    </class>
 </library>

--- a/flexiv_hardware/include/flexiv_hardware/flexiv_dual_hardware_interface.hpp
+++ b/flexiv_hardware/include/flexiv_hardware/flexiv_dual_hardware_interface.hpp
@@ -1,17 +1,17 @@
 /**
- * @file flexiv_hardware_interface.hpp
- * @brief Hardware interface to Flexiv robots for ROS 2 control. Adapted from
- * ros2_control_demos/example_3/hardware/include/ros2_control_demo_example_3/rrbot_system_multi_interface.hpp
- * @copyright Copyright (C) 2016-2024 Flexiv Ltd. All Rights Reserved.
+ * @file flexiv_dual_hardware_interface.hpp
+ * @brief Hardware interface to a pair of Flexiv robots for ROS 2 control.
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
  * @author Flexiv
  */
 
-#ifndef FLEXIV_HARDWARE__FLEXIV_HARDWARE_INTERFACE_HPP_
-#define FLEXIV_HARDWARE__FLEXIV_HARDWARE_INTERFACE_HPP_
+#ifndef FLEXIV_HARDWARE__FLEXIV_DUAL_HARDWARE_INTERFACE_HPP_
+#define FLEXIV_HARDWARE__FLEXIV_DUAL_HARDWARE_INTERFACE_HPP_
 
 #include <memory>
 #include <string>
 #include <vector>
+#include <map>
 
 // ROS
 #include <rclcpp/clock.hpp>
@@ -29,12 +29,15 @@
 #include "flexiv_hardware/visibility_control.h"
 
 // Flexiv
-#include "flexiv/rdk/robot.hpp"
+#include "flexiv/drdk/robot_pair.hpp"
 
 namespace flexiv_hardware {
 
 /** Robot joint space degree of freedoms */
 constexpr size_t kJointDoF = 7;
+
+/** Robot joint space degree of freedoms for a pair of robots */
+constexpr size_t kDualJointDoF = 14;
 
 enum StoppingInterface
 {
@@ -44,10 +47,10 @@ enum StoppingInterface
     STOP_EFFORT
 };
 
-class FlexivHardwareInterface : public hardware_interface::SystemInterface
+class FlexivDualHardwareInterface : public hardware_interface::SystemInterface
 {
 public:
-    RCLCPP_SHARED_PTR_DEFINITIONS(FlexivHardwareInterface)
+    RCLCPP_SHARED_PTR_DEFINITIONS(FlexivDualHardwareInterface)
 
     FLEXIV_HARDWARE_PUBLIC
     hardware_interface::CallbackReturn on_init(
@@ -58,16 +61,6 @@ public:
 
     FLEXIV_HARDWARE_PUBLIC
     std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
-
-    FLEXIV_HARDWARE_PUBLIC
-    hardware_interface::return_type prepare_command_mode_switch(
-        const std::vector<std::string>& start_interfaces,
-        const std::vector<std::string>& stop_interfaces) override;
-
-    FLEXIV_HARDWARE_PUBLIC
-    hardware_interface::return_type perform_command_mode_switch(
-        const std::vector<std::string>& start_interfaces,
-        const std::vector<std::string>& stop_interfaces) override;
 
     FLEXIV_HARDWARE_PUBLIC
     hardware_interface::CallbackReturn on_activate(
@@ -86,8 +79,8 @@ public:
         const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
 private:
-    // Flexiv RDK
-    std::unique_ptr<flexiv::rdk::Robot> robot_;
+    // Flexiv DRDK
+    std::unique_ptr<flexiv::drdk::RobotPair> robot_pair_;
 
     // RDK control mode for joint position and velocity interfaces
     flexiv::rdk::Mode rdk_control_mode_;
@@ -103,15 +96,18 @@ private:
     std::vector<double> hw_states_joint_efforts_;
 
     // Robot States
-    flexiv::rdk::RobotStates hw_flexiv_robot_states_;
-    flexiv::rdk::RobotStates* hw_flexiv_robot_states_addr_ = &hw_flexiv_robot_states_;
+    flexiv::rdk::RobotStates hw_flexiv_robot_states_left_;
+    flexiv::rdk::RobotStates hw_flexiv_robot_states_right_;
+    flexiv::rdk::RobotStates* hw_flexiv_robot_states_addr_left_ = &hw_flexiv_robot_states_left_;
+    flexiv::rdk::RobotStates* hw_flexiv_robot_states_addr_right_ = &hw_flexiv_robot_states_right_;
 
     // GPIO commands and states
     std::vector<double> hw_commands_gpio_out_;
     std::vector<double> hw_states_gpio_in_;
 
     // Current digital output map
-    std::map<unsigned int, bool> current_digital_outputs_;
+    std::map<unsigned int, bool> current_digital_outputs_left_;
+    std::map<unsigned int, bool> current_digital_outputs_right_;
 
     static rclcpp::Logger getLogger();
 
@@ -125,4 +121,4 @@ private:
 };
 
 } /* namespace flexiv_hardware */
-#endif /* FLEXIV_HARDWARE__FLEXIV_HARDWARE_INTERFACE_HPP_ */
+#endif /* FLEXIV_HARDWARE__FLEXIV_DUAL_HARDWARE_INTERFACE_HPP_ */

--- a/flexiv_hardware/include/flexiv_hardware/flexiv_dual_hardware_interface.hpp
+++ b/flexiv_hardware/include/flexiv_hardware/flexiv_dual_hardware_interface.hpp
@@ -63,6 +63,16 @@ public:
     std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
     FLEXIV_HARDWARE_PUBLIC
+    hardware_interface::return_type prepare_command_mode_switch(
+        const std::vector<std::string>& start_interfaces,
+        const std::vector<std::string>& stop_interfaces) override;
+
+    FLEXIV_HARDWARE_PUBLIC
+    hardware_interface::return_type perform_command_mode_switch(
+        const std::vector<std::string>& start_interfaces,
+        const std::vector<std::string>& stop_interfaces) override;
+
+    FLEXIV_HARDWARE_PUBLIC
     hardware_interface::CallbackReturn on_activate(
         const rclcpp_lifecycle::State& previous_state) override;
 

--- a/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
@@ -421,6 +421,137 @@ hardware_interface::return_type FlexivDualHardwareInterface::write(
     return hardware_interface::return_type::OK;
 }
 
+hardware_interface::return_type FlexivDualHardwareInterface::prepare_command_mode_switch(
+    const std::vector<std::string>& start_interfaces,
+    const std::vector<std::string>& stop_interfaces)
+{
+    start_modes_.clear();
+    stop_modes_.clear();
+
+    // Starting interfaces
+    for (const auto& key : start_interfaces) {
+        for (std::size_t i = 0; i < info_.joints.size(); i++) {
+            if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION) {
+                start_modes_.push_back(hardware_interface::HW_IF_POSITION);
+            }
+            if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY) {
+                start_modes_.push_back(hardware_interface::HW_IF_VELOCITY);
+            }
+            if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT) {
+                start_modes_.push_back(hardware_interface::HW_IF_EFFORT);
+            }
+        }
+    }
+    // All joints must be given new command mode at the same time
+    if (start_modes_.size() != 0 && start_modes_.size() != info_.joints.size()) {
+        return hardware_interface::return_type::ERROR;
+    }
+    // All joints must have the same command mode
+    if (start_modes_.size() != 0
+        && !std::equal(start_modes_.begin() + 1, start_modes_.end(), start_modes_.begin())) {
+        return hardware_interface::return_type::ERROR;
+    }
+
+    // Stop motion on all relevant joints that are stopping
+    for (const auto& key : stop_interfaces) {
+        for (std::size_t i = 0; i < info_.joints.size(); i++) {
+            if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION) {
+                stop_modes_.push_back(StoppingInterface::STOP_POSITION);
+            }
+            if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY) {
+                stop_modes_.push_back(StoppingInterface::STOP_VELOCITY);
+            }
+            if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT) {
+                stop_modes_.push_back(StoppingInterface::STOP_EFFORT);
+            }
+        }
+    }
+    // stop all interfaces at the same time
+    if (stop_modes_.size() != 0
+        && (stop_modes_.size() != info_.joints.size()
+            || !std::equal(stop_modes_.begin() + 1, stop_modes_.end(), stop_modes_.begin()))) {
+        return hardware_interface::return_type::ERROR;
+    }
+
+    controllers_initialized_ = true;
+    return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type FlexivDualHardwareInterface::perform_command_mode_switch(
+    const std::vector<std::string>& /*start_interfaces*/,
+    const std::vector<std::string>& /*stop_interfaces*/)
+{
+    if (stop_modes_.size() != 0
+        && std::find(stop_modes_.begin(), stop_modes_.end(), StoppingInterface::STOP_POSITION)
+               != stop_modes_.end()) {
+        position_controller_running_ = false;
+        robot_pair_->Stop();
+    } else if (stop_modes_.size() != 0
+               && std::find(
+                      stop_modes_.begin(), stop_modes_.end(), StoppingInterface::STOP_VELOCITY)
+                      != stop_modes_.end()) {
+        velocity_controller_running_ = false;
+        robot_pair_->Stop();
+    } else if (stop_modes_.size() != 0
+               && std::find(stop_modes_.begin(), stop_modes_.end(), StoppingInterface::STOP_EFFORT)
+                      != stop_modes_.end()) {
+        torque_controller_running_ = false;
+        robot_pair_->Stop();
+    }
+
+    if (start_modes_.size() != 0
+        && std::find(start_modes_.begin(), start_modes_.end(), hardware_interface::HW_IF_POSITION)
+               != start_modes_.end()) {
+        velocity_controller_running_ = false;
+        torque_controller_running_ = false;
+
+        // Hold joints before user commands arrives
+        std::fill(hw_commands_joint_positions_.begin(), hw_commands_joint_positions_.end(),
+            std::numeric_limits<double>::quiet_NaN());
+
+        // Set to joint position or joint impedance mode
+        robot_pair_->SwitchMode(rdk_control_mode_);
+
+        position_controller_running_ = true;
+    } else if (start_modes_.size() != 0
+               && std::find(
+                      start_modes_.begin(), start_modes_.end(), hardware_interface::HW_IF_VELOCITY)
+                      != start_modes_.end()) {
+        position_controller_running_ = false;
+        torque_controller_running_ = false;
+
+        // Hold joints before user commands arrives
+        std::fill(hw_commands_joint_velocities_.begin(), hw_commands_joint_velocities_.end(),
+            std::numeric_limits<double>::quiet_NaN());
+
+        // Set to joint position or joint impedance mode
+        robot_pair_->SwitchMode(rdk_control_mode_);
+
+        velocity_controller_running_ = true;
+    } else if (start_modes_.size() != 0
+               && std::find(
+                      start_modes_.begin(), start_modes_.end(), hardware_interface::HW_IF_EFFORT)
+                      != start_modes_.end()) {
+        position_controller_running_ = false;
+        velocity_controller_running_ = false;
+
+        // Hold joints when starting joint torque controller before user
+        // commands arrives
+        std::fill(hw_commands_joint_efforts_.begin(), hw_commands_joint_efforts_.end(),
+            std::numeric_limits<double>::quiet_NaN());
+
+        // Set to joint torque mode
+        robot_pair_->SwitchMode(flexiv::rdk::Mode::RT_JOINT_TORQUE);
+
+        torque_controller_running_ = true;
+    }
+
+    start_modes_.clear();
+    stop_modes_.clear();
+
+    return hardware_interface::return_type::OK;
+}
+
 } /* namespace flexiv_hardware */
 
 #include "pluginlib/class_list_macros.hpp"

--- a/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
@@ -201,18 +201,26 @@ FlexivDualHardwareInterface::export_state_interfaces()
             info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &hw_states_joint_efforts_[i]));
     }
 
-    // Export robot states for both robots
-    std::string robot_sn_left = info_.hardware_parameters.at("robot_sn_left");
-    state_interfaces.emplace_back(hardware_interface::StateInterface(robot_sn_left,
-        "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_left_)));
-
-    std::string robot_sn_right = info_.hardware_parameters.at("robot_sn_right");
-    state_interfaces.emplace_back(hardware_interface::StateInterface(robot_sn_right,
-        "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_right_)));
-
     // GPIOs
     const std::string prefix_left = info_.hardware_parameters.at("prefix_left");
     const std::string prefix_right = info_.hardware_parameters.at("prefix_right");
+
+    // Remove trailing underscore from prefix to get the robot name used in controllers
+    std::string robot_name_left = prefix_left;
+    if (!robot_name_left.empty() && robot_name_left.back() == '_') {
+        robot_name_left.pop_back();
+    }
+    std::string robot_name_right = prefix_right;
+    if (!robot_name_right.empty() && robot_name_right.back() == '_') {
+        robot_name_right.pop_back();
+    }
+
+    // Export robot states for both robots
+    state_interfaces.emplace_back(hardware_interface::StateInterface(robot_name_left,
+        "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_left_)));
+
+    state_interfaces.emplace_back(hardware_interface::StateInterface(robot_name_right,
+        "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_right_)));
     for (size_t i = 0; i < flexiv::rdk::kIOPorts; i++) {
         state_interfaces.emplace_back(hardware_interface::StateInterface(
             prefix_left + "gpio", "digital_input_" + std::to_string(i), &hw_states_gpio_in_[i]));
@@ -353,55 +361,66 @@ hardware_interface::return_type FlexivDualHardwareInterface::write(
     std::vector<double> max_vel_right(robot_pair_->info().second.DoF, kMaxJointVelocity);
     std::vector<double> max_acc_right(robot_pair_->info().second.DoF, kMaxJointAcceleration);
 
-    bool is_pos_nan = false;
-    bool is_vel_nan = false;
-    bool is_eff_nan = false;
-    for (size_t i = 0; i < kDualJointDoF; i++) {
-        if (hw_commands_joint_positions_[i] != hw_commands_joint_positions_[i]) {
-            is_pos_nan = true;
+    // Populate target vectors, using current state if command is NaN
+    for (size_t i = 0; i < robot_pair_->info().first.DoF; i++) {
+        if (std::isnan(hw_commands_joint_positions_[i])) {
+            target_pos_left[i] = hw_states_joint_positions_[i];
+        } else {
+            target_pos_left[i] = hw_commands_joint_positions_[i];
         }
-        if (hw_commands_joint_velocities_[i] != hw_commands_joint_velocities_[i]) {
-            is_vel_nan = true;
+        if (std::isnan(hw_commands_joint_velocities_[i])) {
+            target_vel_left[i] = 0.0;
+        } else {
+            target_vel_left[i] = hw_commands_joint_velocities_[i];
         }
-        if (hw_commands_joint_efforts_[i] != hw_commands_joint_efforts_[i]) {
-            is_eff_nan = true;
+    }
+
+    for (size_t i = 0; i < robot_pair_->info().second.DoF; i++) {
+        size_t idx = i + robot_pair_->info().first.DoF;
+        if (std::isnan(hw_commands_joint_positions_[idx])) {
+            target_pos_right[i] = hw_states_joint_positions_[idx];
+        } else {
+            target_pos_right[i] = hw_commands_joint_positions_[idx];
+        }
+        if (std::isnan(hw_commands_joint_velocities_[idx])) {
+            target_vel_right[i] = 0.0;
+        } else {
+            target_vel_right[i] = hw_commands_joint_velocities_[idx];
         }
     }
 
     if (position_controller_running_
-        && robot_pair_->mode() == std::pair {rdk_control_mode_, rdk_control_mode_} && !is_pos_nan) {
-        target_pos_left = {hw_commands_joint_positions_.begin(),
-            hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF};
-        target_pos_right = {hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF,
-            hw_commands_joint_positions_.end()};
+        && robot_pair_->mode() == std::pair {rdk_control_mode_, rdk_control_mode_}) {
         robot_pair_->SendJointPosition({target_pos_left, target_pos_right},
             {target_vel_left, target_vel_right}, {max_vel_left, max_vel_right},
             {max_acc_left, max_acc_right});
     } else if (velocity_controller_running_
-               && robot_pair_->mode() == std::pair {rdk_control_mode_, rdk_control_mode_}
-               && !is_vel_nan) {
-        target_pos_left = {hw_commands_joint_positions_.begin(),
-            hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF};
-        target_pos_right = {hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF,
-            hw_commands_joint_positions_.end()};
-        target_vel_left = {hw_commands_joint_velocities_.begin(),
-            hw_commands_joint_velocities_.begin() + robot_pair_->info().first.DoF};
-        target_vel_right = {hw_commands_joint_velocities_.begin() + robot_pair_->info().first.DoF,
-            hw_commands_joint_velocities_.end()};
+               && robot_pair_->mode() == std::pair {rdk_control_mode_, rdk_control_mode_}) {
         robot_pair_->SendJointPosition({target_pos_left, target_pos_right},
             {target_vel_left, target_vel_right}, {max_vel_left, max_vel_right},
             {max_acc_left, max_acc_right});
     } else if (torque_controller_running_
                && robot_pair_->mode()
-                      == std::pair {flexiv::rdk::Mode::RT_JOINT_TORQUE,
-                          flexiv::rdk::Mode::RT_JOINT_TORQUE}
-               && !is_eff_nan) {
+                      == std::pair {
+                          flexiv::rdk::Mode::RT_JOINT_TORQUE, flexiv::rdk::Mode::RT_JOINT_TORQUE}) {
         std::vector<double> target_torque_left(robot_pair_->info().first.DoF);
         std::vector<double> target_torque_right(robot_pair_->info().second.DoF);
-        target_torque_left = {hw_commands_joint_efforts_.begin(),
-            hw_commands_joint_efforts_.begin() + robot_pair_->info().first.DoF};
-        target_torque_right = {hw_commands_joint_efforts_.begin() + robot_pair_->info().first.DoF,
-            hw_commands_joint_efforts_.end()};
+
+        for (size_t i = 0; i < robot_pair_->info().first.DoF; i++) {
+            if (std::isnan(hw_commands_joint_efforts_[i])) {
+                target_torque_left[i] = 0.0;
+            } else {
+                target_torque_left[i] = hw_commands_joint_efforts_[i];
+            }
+        }
+        for (size_t i = 0; i < robot_pair_->info().second.DoF; i++) {
+            size_t idx = i + robot_pair_->info().first.DoF;
+            if (std::isnan(hw_commands_joint_efforts_[idx])) {
+                target_torque_right[i] = 0.0;
+            } else {
+                target_torque_right[i] = hw_commands_joint_efforts_[idx];
+            }
+        }
         robot_pair_->StreamJointTorque({target_torque_left, target_torque_right});
     }
 
@@ -471,10 +490,7 @@ hardware_interface::return_type FlexivDualHardwareInterface::prepare_command_mod
             }
         }
     }
-    // All joints must be given new command mode at the same time
-    if (start_modes_.size() != 0 && start_modes_.size() != info_.joints.size()) {
-        return hardware_interface::return_type::ERROR;
-    }
+
     // All joints must have the same command mode
     if (start_modes_.size() != 0
         && !std::equal(start_modes_.begin() + 1, start_modes_.end(), start_modes_.begin())) {
@@ -494,12 +510,6 @@ hardware_interface::return_type FlexivDualHardwareInterface::prepare_command_mod
                 stop_modes_.push_back(StoppingInterface::STOP_EFFORT);
             }
         }
-    }
-    // stop all interfaces at the same time
-    if (stop_modes_.size() != 0
-        && (stop_modes_.size() != info_.joints.size()
-            || !std::equal(stop_modes_.begin() + 1, stop_modes_.end(), stop_modes_.begin()))) {
-        return hardware_interface::return_type::ERROR;
     }
 
     controllers_initialized_ = true;

--- a/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
@@ -1,0 +1,429 @@
+/**
+ * @file flexiv_dual_hardware_interface.cpp
+ * @brief Hardware interface to a pair of Flexiv robots for ROS 2 control.
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
+ * @author Flexiv
+ */
+
+#include <vector>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/clock.hpp>
+#include <hardware_interface/types/hardware_interface_return_values.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+
+#include "flexiv/drdk/robot_pair.hpp"
+#include "flexiv_hardware/flexiv_dual_hardware_interface.hpp"
+
+namespace {
+constexpr double kMaxJointVelocity = 2.0;
+constexpr double kMaxJointAcceleration = 3.0;
+}
+
+namespace flexiv_hardware {
+
+hardware_interface::CallbackReturn FlexivDualHardwareInterface::on_init(
+    const hardware_interface::HardwareInfo& info)
+{
+    if (hardware_interface::SystemInterface::on_init(info)
+        != hardware_interface::CallbackReturn::SUCCESS) {
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    hw_states_joint_positions_.resize(
+        info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+    hw_states_joint_velocities_.resize(
+        info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+    hw_states_joint_efforts_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+    hw_commands_joint_positions_.resize(
+        info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+    hw_commands_joint_velocities_.resize(
+        info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+    hw_commands_joint_efforts_.resize(
+        info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+    // 16 ports per robot
+    hw_states_gpio_in_.resize(flexiv::rdk::kIOPorts * 2, std::numeric_limits<double>::quiet_NaN());
+    hw_commands_gpio_out_.resize(
+        flexiv::rdk::kIOPorts * 2, std::numeric_limits<double>::quiet_NaN());
+    stop_modes_ = {StoppingInterface::NONE, StoppingInterface::NONE, StoppingInterface::NONE,
+        StoppingInterface::NONE, StoppingInterface::NONE, StoppingInterface::NONE,
+        StoppingInterface::NONE};
+    start_modes_ = {};
+    position_controller_running_ = false;
+    velocity_controller_running_ = false;
+    torque_controller_running_ = false;
+    controllers_initialized_ = false;
+
+    if (info_.joints.size() != kDualJointDoF) {
+        RCLCPP_FATAL(
+            getLogger(), "Got %ld joints. Expected %ld.", info_.joints.size(), kDualJointDoF);
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    for (const hardware_interface::ComponentInfo& joint : info_.joints) {
+        if (joint.command_interfaces.size() != 3) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' has %ld command interfaces found. 3 expected.",
+                joint.name.c_str(), joint.command_interfaces.size());
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' have %s command interfaces found. '%s' expected.",
+                joint.name.c_str(), joint.command_interfaces[0].name.c_str(),
+                hardware_interface::HW_IF_POSITION);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.command_interfaces[1].name != hardware_interface::HW_IF_VELOCITY) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' have %s command interfaces found. '%s' expected.",
+                joint.name.c_str(), joint.command_interfaces[1].name.c_str(),
+                hardware_interface::HW_IF_VELOCITY);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.command_interfaces[2].name != hardware_interface::HW_IF_EFFORT) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' have %s command interfaces found. '%s' expected.",
+                joint.name.c_str(), joint.command_interfaces[2].name.c_str(),
+                hardware_interface::HW_IF_EFFORT);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.state_interfaces.size() != 3) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' has %ld state interfaces found. 3 expected.",
+                joint.name.c_str(), joint.state_interfaces.size());
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' have %s state interfaces found. '%s' expected.",
+                joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
+                hardware_interface::HW_IF_POSITION);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.state_interfaces[1].name != hardware_interface::HW_IF_VELOCITY) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' have %s state interfaces found. '%s' expected.",
+                joint.name.c_str(), joint.state_interfaces[1].name.c_str(),
+                hardware_interface::HW_IF_VELOCITY);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        if (joint.state_interfaces[2].name != hardware_interface::HW_IF_EFFORT) {
+            RCLCPP_FATAL(getLogger(), "Joint '%s' have %s state interfaces found. '%s' expected.",
+                joint.name.c_str(), joint.state_interfaces[2].name.c_str(),
+                hardware_interface::HW_IF_EFFORT);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+    }
+
+    std::string robot_sn_left;
+    std::string robot_sn_right;
+    try {
+        robot_sn_left = info_.hardware_parameters.at("robot_sn_left");
+        robot_sn_right = info_.hardware_parameters.at("robot_sn_right");
+    } catch (const std::out_of_range& ex) {
+        RCLCPP_FATAL(getLogger(), "Parameter 'robot_sn_left' or 'robot_sn_right' not set");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    try {
+        auto rdk_control_mode_str = info_.hardware_parameters.at("rdk_control_mode");
+        if (rdk_control_mode_str == "joint_position") {
+            rdk_control_mode_ = flexiv::rdk::Mode::NRT_JOINT_POSITION;
+        } else if (rdk_control_mode_str == "joint_impedance") {
+            rdk_control_mode_ = flexiv::rdk::Mode::NRT_JOINT_IMPEDANCE;
+        } else {
+            RCLCPP_FATAL(getLogger(),
+                "Parameter 'rdk_control_mode' has invalid value '%s'. Options: joint_position, "
+                "joint_impedance",
+                rdk_control_mode_str.c_str());
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+    } catch (const std::out_of_range& ex) {
+        RCLCPP_FATAL(getLogger(), "Parameter 'rdk_control_mode' not set");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    try {
+        RCLCPP_INFO(getLogger(), "Connecting to robots %s and %s ...", robot_sn_left.c_str(),
+            robot_sn_right.c_str());
+        robot_pair_ = std::make_unique<flexiv::drdk::RobotPair>(
+            std::make_pair(robot_sn_left, robot_sn_right));
+    } catch (const std::exception& e) {
+        RCLCPP_FATAL(getLogger(), "Could not connect to robots");
+        RCLCPP_FATAL(getLogger(), e.what());
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    RCLCPP_INFO(getLogger(), "Successfully connected to robots");
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+rclcpp::Logger FlexivDualHardwareInterface::getLogger()
+{
+    return rclcpp::get_logger("FlexivDualHardwareInterface");
+}
+
+std::vector<hardware_interface::StateInterface>
+FlexivDualHardwareInterface::export_state_interfaces()
+{
+    std::vector<hardware_interface::StateInterface> state_interfaces;
+    for (std::size_t i = 0; i < info_.joints.size(); i++) {
+        state_interfaces.emplace_back(hardware_interface::StateInterface(info_.joints[i].name,
+            hardware_interface::HW_IF_POSITION, &hw_states_joint_positions_[i]));
+        state_interfaces.emplace_back(hardware_interface::StateInterface(info_.joints[i].name,
+            hardware_interface::HW_IF_VELOCITY, &hw_states_joint_velocities_[i]));
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+            info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &hw_states_joint_efforts_[i]));
+    }
+
+    // Export robot states for both robots
+    std::string robot_sn_left = info_.hardware_parameters.at("robot_sn_left");
+    state_interfaces.emplace_back(hardware_interface::StateInterface(robot_sn_left,
+        "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_left_)));
+
+    std::string robot_sn_right = info_.hardware_parameters.at("robot_sn_right");
+    state_interfaces.emplace_back(hardware_interface::StateInterface(robot_sn_right,
+        "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_right_)));
+
+    // GPIOs
+    const std::string prefix = info_.hardware_parameters.at("prefix");
+    for (size_t i = 0; i < flexiv::rdk::kIOPorts * 2; i++) {
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+            prefix + "gpio", "digital_input_" + std::to_string(i), &hw_states_gpio_in_[i]));
+    }
+
+    return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface>
+FlexivDualHardwareInterface::export_command_interfaces()
+{
+    std::vector<hardware_interface::CommandInterface> command_interfaces;
+    for (size_t i = 0; i < info_.joints.size(); i++) {
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(info_.joints[i].name,
+            hardware_interface::HW_IF_POSITION, &hw_commands_joint_positions_[i]));
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(info_.joints[i].name,
+            hardware_interface::HW_IF_VELOCITY, &hw_commands_joint_velocities_[i]));
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(info_.joints[i].name,
+            hardware_interface::HW_IF_EFFORT, &hw_commands_joint_efforts_[i]));
+    }
+
+    const std::string prefix = info_.hardware_parameters.at("prefix");
+    for (size_t i = 0; i < flexiv::rdk::kIOPorts * 2; i++) {
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+            prefix + "gpio", "digital_output_" + std::to_string(i), &hw_commands_gpio_out_[i]));
+    }
+
+    return command_interfaces;
+}
+
+hardware_interface::CallbackReturn FlexivDualHardwareInterface::on_activate(
+    const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    RCLCPP_INFO(getLogger(), "Starting... please wait...");
+
+    try {
+        // Clear fault on the connected robots if any
+        if (robot_pair_->fault()) {
+            RCLCPP_WARN(
+                getLogger(), "Fault occurred on one of the connected robots, trying to clear ...");
+            // Try to clear the fault for both robots
+            auto result = robot_pair_->ClearFault();
+            // If fault is not cleared on both robots
+            if (!(result.first && result.second)) {
+                RCLCPP_ERROR(getLogger(), "Fault cannot be cleared, exiting ...");
+                return hardware_interface::CallbackReturn::ERROR;
+            }
+            RCLCPP_INFO(getLogger(), "Fault on the connected robot is cleared");
+        }
+
+        // Check the DoF of both robots
+        if (robot_pair_->info().first.DoF != kJointDoF
+            || robot_pair_->info().second.DoF != kJointDoF) {
+            RCLCPP_FATAL(getLogger(),
+                "Connected robots DoF (%ld, %ld) do not match expected DoF (%ld, %ld)",
+                robot_pair_->info().first.DoF, robot_pair_->info().second.DoF, kJointDoF,
+                kJointDoF);
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        // Enable the pair of robots
+        RCLCPP_INFO(getLogger(), "Enabling robots ...");
+        robot_pair_->Enable();
+
+        // Wait for both robots to become operational
+        while (!robot_pair_->operational()) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+        RCLCPP_INFO(getLogger(), "Both robots are now operational");
+    } catch (const std::exception& e) {
+        RCLCPP_FATAL(getLogger(), "Could not enable the robots");
+        RCLCPP_FATAL(getLogger(), e.what());
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    RCLCPP_INFO(getLogger(), "System successfully started!");
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn FlexivDualHardwareInterface::on_deactivate(
+    const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    RCLCPP_INFO(getLogger(), "Stopping... please wait...");
+    robot_pair_->Stop();
+    RCLCPP_INFO(getLogger(), "System successfully stopped!");
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type FlexivDualHardwareInterface::read(
+    const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+    if (robot_pair_->operational()) {
+        auto robot_states_pair = robot_pair_->states();
+        hw_flexiv_robot_states_left_ = robot_states_pair.first;
+        hw_flexiv_robot_states_right_ = robot_states_pair.second;
+
+        // Robot Left
+        for (size_t i = 0; i < 7; i++) {
+            hw_states_joint_positions_[i] = robot_pair_->states().first.q[i];
+            hw_states_joint_velocities_[i] = robot_pair_->states().first.dq[i];
+            hw_states_joint_efforts_[i] = robot_pair_->states().first.tau[i];
+        }
+        // Robot Right
+        for (size_t i = 0; i < 7; i++) {
+            hw_states_joint_positions_[i + 7] = robot_pair_->states().second.q[i];
+            hw_states_joint_velocities_[i + 7] = robot_pair_->states().second.dq[i];
+            hw_states_joint_efforts_[i + 7] = robot_pair_->states().second.tau[i];
+        }
+
+        // Read GPIO inputs
+        auto gpio_inputs = robot_pair_->digital_inputs();
+        for (size_t i = 0; i < flexiv::rdk::kIOPorts; i++) {
+            hw_states_gpio_in_[i] = static_cast<double>(gpio_inputs.first[i]);
+            hw_states_gpio_in_[i + flexiv::rdk::kIOPorts]
+                = static_cast<double>(gpio_inputs.second[i]);
+        }
+    }
+    return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type FlexivDualHardwareInterface::write(
+    const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+    // Initialize target position and velocity vectors
+    std::vector<double> target_pos_left(robot_pair_->info().first.DoF);
+    std::vector<double> target_vel_left(robot_pair_->info().first.DoF);
+    std::vector<double> max_vel_left(robot_pair_->info().first.DoF, kMaxJointVelocity);
+    std::vector<double> max_acc_left(robot_pair_->info().first.DoF, kMaxJointAcceleration);
+
+    std::vector<double> target_pos_right(robot_pair_->info().second.DoF);
+    std::vector<double> target_vel_right(robot_pair_->info().second.DoF);
+    std::vector<double> max_vel_right(robot_pair_->info().second.DoF, kMaxJointVelocity);
+    std::vector<double> max_acc_right(robot_pair_->info().second.DoF, kMaxJointAcceleration);
+
+    bool is_pos_nan = false;
+    bool is_vel_nan = false;
+    bool is_eff_nan = false;
+    for (size_t i = 0; i < kDualJointDoF; i++) {
+        if (hw_commands_joint_positions_[i] != hw_commands_joint_positions_[i]) {
+            is_pos_nan = true;
+        }
+        if (hw_commands_joint_velocities_[i] != hw_commands_joint_velocities_[i]) {
+            is_vel_nan = true;
+        }
+        if (hw_commands_joint_efforts_[i] != hw_commands_joint_efforts_[i]) {
+            is_eff_nan = true;
+        }
+    }
+
+    if (position_controller_running_
+        && robot_pair_->mode() == std::pair {rdk_control_mode_, rdk_control_mode_} && !is_pos_nan) {
+        target_pos_left = {hw_commands_joint_positions_.begin(),
+            hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF};
+        target_pos_right = {hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF,
+            hw_commands_joint_positions_.end()};
+        robot_pair_->SendJointPosition({target_pos_left, target_pos_right},
+            {target_vel_left, target_vel_right}, {max_vel_left, max_vel_right},
+            {max_acc_left, max_acc_right});
+    } else if (velocity_controller_running_
+               && robot_pair_->mode() == std::pair {rdk_control_mode_, rdk_control_mode_}
+               && !is_vel_nan) {
+        target_pos_left = {hw_commands_joint_positions_.begin(),
+            hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF};
+        target_pos_right = {hw_commands_joint_positions_.begin() + robot_pair_->info().first.DoF,
+            hw_commands_joint_positions_.end()};
+        target_vel_left = {hw_commands_joint_velocities_.begin(),
+            hw_commands_joint_velocities_.begin() + robot_pair_->info().first.DoF};
+        target_vel_right = {hw_commands_joint_velocities_.begin() + robot_pair_->info().first.DoF,
+            hw_commands_joint_velocities_.end()};
+        robot_pair_->SendJointPosition({target_pos_left, target_pos_right},
+            {target_vel_left, target_vel_right}, {max_vel_left, max_vel_right},
+            {max_acc_left, max_acc_right});
+    } else if (torque_controller_running_
+               && robot_pair_->mode()
+                      == std::pair {flexiv::rdk::Mode::RT_JOINT_TORQUE,
+                          flexiv::rdk::Mode::RT_JOINT_TORQUE}
+               && !is_eff_nan) {
+        std::vector<double> target_torque_left(robot_pair_->info().first.DoF);
+        std::vector<double> target_torque_right(robot_pair_->info().second.DoF);
+        target_torque_left = {hw_commands_joint_efforts_.begin(),
+            hw_commands_joint_efforts_.begin() + robot_pair_->info().first.DoF};
+        target_torque_right = {hw_commands_joint_efforts_.begin() + robot_pair_->info().first.DoF,
+            hw_commands_joint_efforts_.end()};
+        robot_pair_->StreamJointTorque({target_torque_left, target_torque_right});
+    }
+
+    // Write digital outputs
+    std::map<unsigned int, bool> digital_outputs_left;
+    std::map<unsigned int, bool> digital_outputs_right;
+    for (size_t i = 0; i < flexiv::rdk::kIOPorts; i++) {
+        if (hw_commands_gpio_out_[i] == hw_commands_gpio_out_[i]) {
+            digital_outputs_left[i] = static_cast<bool>(hw_commands_gpio_out_[i]);
+        }
+        if (hw_commands_gpio_out_[i + flexiv::rdk::kIOPorts]
+            == hw_commands_gpio_out_[i + flexiv::rdk::kIOPorts]) {
+            digital_outputs_right[i]
+                = static_cast<bool>(hw_commands_gpio_out_[i + flexiv::rdk::kIOPorts]);
+        }
+    }
+    // Check if there is any change in digital outputs before sending
+    bool digital_outputs_changed = false;
+    for (const auto& [port, value] : digital_outputs_left) {
+        if (current_digital_outputs_left_[port] != value) {
+            digital_outputs_changed = true;
+            current_digital_outputs_left_[port] = value;
+        }
+    }
+    for (const auto& [port, value] : digital_outputs_right) {
+        if (current_digital_outputs_right_[port] != value) {
+            digital_outputs_changed = true;
+            current_digital_outputs_right_[port] = value;
+        }
+    }
+    current_digital_outputs_left_.clear();
+    current_digital_outputs_right_.clear();
+    for (const auto& [port, value] : digital_outputs_left) {
+        current_digital_outputs_left_[port] = value;
+    }
+    for (const auto& [port, value] : digital_outputs_right) {
+        current_digital_outputs_right_[port] = value;
+    }
+
+    // Set digital outputs
+    if (digital_outputs_changed
+        && (!digital_outputs_left.empty() || !digital_outputs_right.empty())) {
+        robot_pair_->SetDigitalOutputs({digital_outputs_left, digital_outputs_right});
+    }
+
+    return hardware_interface::return_type::OK;
+}
+
+} /* namespace flexiv_hardware */
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+    flexiv_hardware::FlexivDualHardwareInterface, hardware_interface::SystemInterface)

--- a/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_dual_hardware_interface.cpp
@@ -146,11 +146,33 @@ hardware_interface::CallbackReturn FlexivDualHardwareInterface::on_init(
         return hardware_interface::CallbackReturn::ERROR;
     }
 
+    // Read translation parameters
+    double left_x = 0.0, left_y = 0.0, left_z = 0.0;
+    double right_x = 0.0, right_y = 0.0, right_z = 0.0;
+    try {
+        if (info_.hardware_parameters.count("translation_left_x")) {
+            left_x = std::stod(info_.hardware_parameters.at("translation_left_x"));
+            left_y = std::stod(info_.hardware_parameters.at("translation_left_y"));
+            left_z = std::stod(info_.hardware_parameters.at("translation_left_z"));
+        }
+        if (info_.hardware_parameters.count("translation_right_x")) {
+            right_x = std::stod(info_.hardware_parameters.at("translation_right_x"));
+            right_y = std::stod(info_.hardware_parameters.at("translation_right_y"));
+            right_z = std::stod(info_.hardware_parameters.at("translation_right_z"));
+        }
+    } catch (const std::exception& ex) {
+        RCLCPP_WARN(getLogger(), "Failed to parse translation parameters, using default (0,0,0)");
+    }
+
+    std::pair<std::array<double, 3>, std::array<double, 3>> translations;
+    translations.first = {left_x, left_y, left_z};
+    translations.second = {right_x, right_y, right_z};
+
     try {
         RCLCPP_INFO(getLogger(), "Connecting to robots %s and %s ...", robot_sn_left.c_str(),
             robot_sn_right.c_str());
         robot_pair_ = std::make_unique<flexiv::drdk::RobotPair>(
-            std::make_pair(robot_sn_left, robot_sn_right));
+            std::make_pair(robot_sn_left, robot_sn_right), translations);
     } catch (const std::exception& e) {
         RCLCPP_FATAL(getLogger(), "Could not connect to robots");
         RCLCPP_FATAL(getLogger(), e.what());
@@ -189,10 +211,13 @@ FlexivDualHardwareInterface::export_state_interfaces()
         "flexiv_robot_states", reinterpret_cast<double*>(&hw_flexiv_robot_states_addr_right_)));
 
     // GPIOs
-    const std::string prefix = info_.hardware_parameters.at("prefix");
-    for (size_t i = 0; i < flexiv::rdk::kIOPorts * 2; i++) {
+    const std::string prefix_left = info_.hardware_parameters.at("prefix_left");
+    const std::string prefix_right = info_.hardware_parameters.at("prefix_right");
+    for (size_t i = 0; i < flexiv::rdk::kIOPorts; i++) {
         state_interfaces.emplace_back(hardware_interface::StateInterface(
-            prefix + "gpio", "digital_input_" + std::to_string(i), &hw_states_gpio_in_[i]));
+            prefix_left + "gpio", "digital_input_" + std::to_string(i), &hw_states_gpio_in_[i]));
+        state_interfaces.emplace_back(hardware_interface::StateInterface(prefix_right + "gpio",
+            "digital_input_" + std::to_string(i), &hw_states_gpio_in_[i + flexiv::rdk::kIOPorts]));
     }
 
     return state_interfaces;
@@ -211,10 +236,14 @@ FlexivDualHardwareInterface::export_command_interfaces()
             hardware_interface::HW_IF_EFFORT, &hw_commands_joint_efforts_[i]));
     }
 
-    const std::string prefix = info_.hardware_parameters.at("prefix");
-    for (size_t i = 0; i < flexiv::rdk::kIOPorts * 2; i++) {
-        command_interfaces.emplace_back(hardware_interface::CommandInterface(
-            prefix + "gpio", "digital_output_" + std::to_string(i), &hw_commands_gpio_out_[i]));
+    const std::string prefix_left = info_.hardware_parameters.at("prefix_left");
+    const std::string prefix_right = info_.hardware_parameters.at("prefix_right");
+    for (size_t i = 0; i < flexiv::rdk::kIOPorts; i++) {
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(prefix_left + "gpio",
+            "digital_output_" + std::to_string(i), &hw_commands_gpio_out_[i]));
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(prefix_right + "gpio",
+            "digital_output_" + std::to_string(i),
+            &hw_commands_gpio_out_[i + flexiv::rdk::kIOPorts]));
     }
 
     return command_interfaces;

--- a/flexiv_hardware/src/flexiv_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_hardware_interface.cpp
@@ -119,7 +119,7 @@ hardware_interface::CallbackReturn FlexivHardwareInterface::on_init(
 
     std::string robot_sn;
     try {
-        robot_sn = info_.hardware_parameters["robot_sn"];
+        robot_sn = info_.hardware_parameters.at("robot_sn");
     } catch (const std::out_of_range& ex) {
         RCLCPP_FATAL(getLogger(), "Parameter 'robot_sn' not set");
         return hardware_interface::CallbackReturn::ERROR;
@@ -304,36 +304,36 @@ hardware_interface::return_type FlexivHardwareInterface::write(
     std::vector<double> max_vel(robot_->info().DoF, kMaxJointVelocity);
     std::vector<double> max_acc(robot_->info().DoF, kMaxJointAcceleration);
 
-    bool isNanPos = false;
-    bool isNanVel = false;
-    bool isNanEff = false;
+    bool is_pos_nan = false;
+    bool is_vel_nan = false;
+    bool is_eff_nan = false;
     for (std::size_t i = 0; i < robot_->info().DoF; i++) {
         if (hw_commands_joint_positions_[i] != hw_commands_joint_positions_[i]) {
-            isNanPos = true;
+            is_pos_nan = true;
         }
         if (hw_commands_joint_velocities_[i] != hw_commands_joint_velocities_[i]) {
-            isNanVel = true;
+            is_vel_nan = true;
         }
         if (hw_commands_joint_efforts_[i] != hw_commands_joint_efforts_[i]) {
-            isNanEff = true;
+            is_eff_nan = true;
         }
     }
 
-    if (position_controller_running_ && robot_->mode() == rdk_control_mode_ && !isNanPos) {
+    if (position_controller_running_ && robot_->mode() == rdk_control_mode_ && !is_pos_nan) {
         target_pos = hw_commands_joint_positions_;
         robot_->SendJointPosition(target_pos, target_vel, max_vel, max_acc);
-    } else if (velocity_controller_running_ && robot_->mode() == rdk_control_mode_ && !isNanVel) {
+    } else if (velocity_controller_running_ && robot_->mode() == rdk_control_mode_ && !is_vel_nan) {
         target_pos = hw_commands_joint_positions_;
         target_vel = hw_commands_joint_velocities_;
         robot_->SendJointPosition(target_pos, target_vel, max_vel, max_acc);
     } else if (torque_controller_running_ && robot_->mode() == flexiv::rdk::Mode::RT_JOINT_TORQUE
-               && !isNanEff) {
+               && !is_eff_nan) {
         std::vector<double> target_torque(robot_->info().DoF);
         target_torque = hw_commands_joint_efforts_;
         robot_->StreamJointTorque(target_torque, true, true);
     }
 
-    // Write digital output
+    // Write digital outputs
     std::map<unsigned int, bool> digital_outputs;
     for (size_t i = 0; i < hw_commands_gpio_out_.size(); i++) {
         if (hw_commands_gpio_out_[i] != hw_commands_gpio_out_[i]) {

--- a/flexiv_moveit_config/config/dual_arm/kinematics_dual.yaml
+++ b/flexiv_moveit_config/config/dual_arm/kinematics_dual.yaml
@@ -1,0 +1,8 @@
+$(var prefix_left)arm:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.05
+$(var prefix_right)arm:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.05

--- a/flexiv_moveit_config/config/dual_arm/moveit_controllers_dual.yaml
+++ b/flexiv_moveit_config/config/dual_arm/moveit_controllers_dual.yaml
@@ -1,0 +1,45 @@
+controller_names:
+  - left_rizon_arm_controller
+  - right_rizon_arm_controller
+  - left_gripper_node
+  - right_gripper_node
+
+left_rizon_arm_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: true
+  joints:
+    - $(var prefix_left)joint1
+    - $(var prefix_left)joint2
+    - $(var prefix_left)joint3
+    - $(var prefix_left)joint4
+    - $(var prefix_left)joint5
+    - $(var prefix_left)joint6
+    - $(var prefix_left)joint7
+
+right_rizon_arm_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: true
+  joints:
+    - $(var prefix_right)joint1
+    - $(var prefix_right)joint2
+    - $(var prefix_right)joint3
+    - $(var prefix_right)joint4
+    - $(var prefix_right)joint5
+    - $(var prefix_right)joint6
+    - $(var prefix_right)joint7
+
+left_gripper_node:
+  action_ns: gripper_action
+  type: GripperCommand
+  default: true
+  joints:
+    - $(var prefix_left)finger_width_joint
+
+right_gripper_node:
+  action_ns: gripper_action
+  type: GripperCommand
+  default: true
+  joints:
+    - $(var prefix_right)finger_width_joint

--- a/flexiv_moveit_config/config/dual_arm/ompl_planning_dual.yaml
+++ b/flexiv_moveit_config/config/dual_arm/ompl_planning_dual.yaml
@@ -1,0 +1,176 @@
+planner_configs:
+  SBLkConfigDefault:
+    type: geometric::SBL
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  ESTkConfigDefault:
+    type: geometric::EST
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability. default: 0.05
+  LBKPIECEkConfigDefault:
+    type: geometric::LBKPIECE
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9 # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5 # Accept partially valid moves above fraction. default: 0.5
+  BKPIECEkConfigDefault:
+    type: geometric::BKPIECE
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9 # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5 # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5 # Accept partially valid moves above fraction. default: 0.5
+  KPIECEkConfigDefault:
+    type: geometric::KPIECE
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability. default: 0.05
+    border_fraction: 0.9 # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5 # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5 # Accept partially valid moves above fraction. default: 0.5
+  RRTkConfigDefault:
+    type: geometric::RRT
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability? default: 0.05
+  RRTConnectkConfigDefault:
+    type: geometric::RRTConnect
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  RRTstarkConfigDefault:
+    type: geometric::RRTstar
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1 # Stop collision checking as soon as C-free parent found. default 1
+  TRRTkConfigDefault:
+    type: geometric::TRRT
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10 # when to start increasing temp. default: 10
+    temp_change_factor: 2.0 # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10 # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6 # initial temperature. default: 10e-6
+    frountier_threshold: 0.0 # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
+    frountierNodeRatio: 0.1 # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0 # value used to normalize expression. default: 0.0 set in setup()
+  PRMkConfigDefault:
+    type: geometric::PRM
+    max_nearest_neighbors: 10 # use k nearest neighbors. default: 10
+  PRMstarkConfigDefault:
+    type: geometric::PRMstar
+  FMTkConfigDefault:
+    type: geometric::FMT
+    num_samples: 1000 # number of states that the planner should sample. default: 1000
+    radius_multiplier: 1.1 # multiplier used for the nearest neighbors search radius. default: 1.1
+    nearest_k: 1 # use Knearest strategy. default: 1
+    cache_cc: 1 # use collision checking cache. default: 1
+    heuristics: 0 # activate cost to go heuristics. default: 0
+    extended_fmt: 1 # activate the extended FMT*: adding new samples if planner does not finish successfully. default: 1
+  BFMTkConfigDefault:
+    type: geometric::BFMT
+    num_samples: 1000 # number of states that the planner should sample. default: 1000
+    radius_multiplier: 1.0 # multiplier used for the nearest neighbors search radius. default: 1.0
+    nearest_k: 1 # use the Knearest strategy. default: 1
+    balanced: 0 # exploration strategy: balanced true expands one tree every iteration. False will select the tree with lowest maximum cost to go. default: 1
+    optimality: 1 # termination strategy: optimality true finishes when the best possible path is found. Otherwise, the algorithm will finish when the first feasible path is found. default: 1
+    heuristics: 1 # activates cost to go heuristics. default: 1
+    cache_cc: 1 # use the collision checking cache. default: 1
+    extended_fmt: 1 # Activates the extended FMT*: adding new samples if planner does not finish successfully. default: 1
+  PDSTkConfigDefault:
+    type: geometric::PDST
+  STRIDEkConfigDefault:
+    type: geometric::STRIDE
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability. default: 0.05
+    use_projected_distance: 0 # whether nearest neighbors are computed based on distances in a projection of the state rather distances in the state space itself. default: 0
+    degree: 16 # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16
+    max_degree: 18 # max degree of a node in the GNAT. default: 12
+    min_degree: 12 # min degree of a node in the GNAT. default: 12
+    max_pts_per_leaf: 6 # max points per leaf in the GNAT. default: 6
+    estimated_dimension: 0.0 # estimated dimension of the free space. default: 0.0
+    min_valid_path_fraction: 0.2 # Accept partially valid moves above fraction. default: 0.2
+  BiTRRTkConfigDefault:
+    type: geometric::BiTRRT
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    temp_change_factor: 0.1 # how much to increase or decrease temp. default: 0.1
+    init_temperature: 100 # initial temperature. default: 100
+    frountier_threshold: 0.0 # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
+    frountier_node_ratio: 0.1 # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    cost_threshold: 1e300 # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
+  LBTRRTkConfigDefault:
+    type: geometric::LBTRRT
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability. default: 0.05
+    epsilon: 0.4 # optimality approximation factor. default: 0.4
+  BiESTkConfigDefault:
+    type: geometric::BiEST
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  ProjESTkConfigDefault:
+    type: geometric::ProjEST
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05 # When close to goal select goal, with this probability. default: 0.05
+  LazyPRMkConfigDefault:
+    type: geometric::LazyPRM
+    range: 0.0 # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  LazyPRMstarkConfigDefault:
+    type: geometric::LazyPRMstar
+  SPARSkConfigDefault:
+    type: geometric::SPARS
+    stretch_factor: 3.0 # roadmap spanner stretch factor. multiplicative upper bound on path quality. It does not make sense to make this parameter more than 3. default: 3.0
+    sparse_delta_fraction: 0.25 # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
+    dense_delta_fraction: 0.001 # delta fraction for interface detection. default: 0.001
+    max_failures: 1000 # maximum consecutive failure limit. default: 1000
+  SPARStwokConfigDefault:
+    type: geometric::SPARStwo
+    stretch_factor: 3.0 # roadmap spanner stretch factor. multiplicative upper bound on path quality. It does not make sense to make this parameter more than 3. default: 3.0
+    sparse_delta_fraction: 0.25 # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
+    dense_delta_fraction: 0.001 # delta fraction for interface detection. default: 0.001
+    max_failures: 5000 # maximum consecutive failure limit. default: 5000
+  TrajOptDefault:
+    type: geometric::TrajOpt
+left_rizon_arm:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+    - FMTkConfigDefault
+    - BFMTkConfigDefault
+    - PDSTkConfigDefault
+    - STRIDEkConfigDefault
+    - BiTRRTkConfigDefault
+    - LBTRRTkConfigDefault
+    - BiESTkConfigDefault
+    - ProjESTkConfigDefault
+    - LazyPRMkConfigDefault
+    - LazyPRMstarkConfigDefault
+    - SPARSkConfigDefault
+    - SPARStwokConfigDefault
+    - TrajOptDefault
+right_rizon_arm:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+    - FMTkConfigDefault
+    - BFMTkConfigDefault
+    - PDSTkConfigDefault
+    - STRIDEkConfigDefault
+    - BiTRRTkConfigDefault
+    - LBTRRTkConfigDefault
+    - BiESTkConfigDefault
+    - ProjESTkConfigDefault
+    - LazyPRMkConfigDefault
+    - LazyPRMstarkConfigDefault
+    - SPARSkConfigDefault
+    - SPARStwokConfigDefault
+    - TrajOptDefault

--- a/flexiv_moveit_config/rviz/moveit.rviz
+++ b/flexiv_moveit_config/rviz/moveit.rviz
@@ -144,53 +144,53 @@ Visualization Manager:
           Expand Tree: false
           Link Tree Style: Links in Alphabetic Order
           base_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        flange:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        link1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        link2:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        link3:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        link4:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        link5:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        link6:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        link7:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        world:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          flange:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/flexiv_moveit_config/srdf/rizon_dual.srdf.xacro
+++ b/flexiv_moveit_config/srdf/rizon_dual.srdf.xacro
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="rizon_dual">
+    <!-- parameters -->
+    <xacro:arg name="robot_sn_left" default="" />
+    <xacro:arg name="robot_sn_right" default="" />
+    <xacro:arg name="load_gripper_left" default="false" />
+    <xacro:arg name="load_gripper_right" default="false" />
+    <xacro:arg name="load_mounted_ft_sensor_left" default="false" />
+    <xacro:arg name="load_mounted_ft_sensor_right" default="false" />
+    <xacro:arg name="prefix_left" default="left_" />
+    <xacro:arg name="prefix_right" default="right_" />
+
+    <xacro:include filename="$(find flexiv_moveit_config)/srdf/rizon_macro.srdf.xacro" />
+
+    <!-- Left Arm -->
+    <xacro:rizon_srdf arm_prefix="$(arg prefix_left)" robot_sn="$(arg robot_sn_left)"
+        load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_left)" />
+
+    <!-- Right Arm -->
+    <xacro:rizon_srdf arm_prefix="$(arg prefix_right)" robot_sn="$(arg robot_sn_right)"
+        load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_right)" />
+
+    <!-- Load grippers -->
+    <xacro:if value="$(arg load_gripper_left)">
+        <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
+        <xacro:grav_srdf arm_prefix="$(arg prefix_left)" robot_sn="$(arg robot_sn_left)"
+            load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_left)" />
+    </xacro:if>
+
+    <xacro:if value="$(arg load_gripper_right)">
+        <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
+        <xacro:grav_srdf arm_prefix="$(arg prefix_right)" robot_sn="$(arg robot_sn_right)"
+            load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_right)" />
+    </xacro:if>
+
+</robot>

--- a/flexiv_moveit_config/srdf/rizon_macro.srdf.xacro
+++ b/flexiv_moveit_config/srdf/rizon_macro.srdf.xacro
@@ -4,11 +4,11 @@
         <!-- Prefix defaults to 'arm_prefix_robot_sn' -->
         <xacro:property name="prefix" value="${arm_prefix + robot_sn + '_'}" />
 
-        <group name="rizon_arm">
+        <group name="${prefix}arm">
             <chain base_link="${prefix}base_link" tip_link="${prefix}flange" />
         </group>
 
-        <group_state name="${prefix}home" group="rizon_arm">
+        <group_state name="${prefix}home" group="${prefix}arm">
             <joint name="${prefix}joint1" value="0" />
             <joint name="${prefix}joint2" value="${-2*pi/9}" />
             <joint name="${prefix}joint3" value="0" />


### PR DESCRIPTION
Add DRDK hardware interface
- Add `FlexivDualHardwareInterface`
- Remove `flexiv_rdk` submodule in `flexiv_hardware`
- Update `flexiv_moveit_config` to add dual Rizon robot configuration and launch files for MoveIt
- Update README to include optional `flexiv_drdk` installation and example launch command
- Add Flexiv dual robot launch and config files in `flexiv_bringup`
- Update GitHub action workflow script for `flexiv_drdk` setup

<img width="1849" height="1019" alt="Screenshot from 2025-12-16 17-20-32" src="https://github.com/user-attachments/assets/2eca7530-3448-4fc0-b330-98fcc369db94" />

