### PR TITLE
Bugfix/Support lite RDK instance in gripper node

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,13 +263,21 @@ ros2 topic pub /Rizon4_123456/gpio_outputs flexiv_msgs/msg/GPIOStates "{states: 
 
 The gripper control is implemented in the `flexiv_gripper` package to interface with the gripper that is connected to the robot.
 
-Start the `flexiv_gripper_node` with the following launch file, the default gripper is Flexiv Grav (Flexiv-GN01):
+Start the `flexiv_gripper_node` with the following launch file, the default gripper is Flexiv Grav (Flexiv-GN01). This standalone launch uses a normal RDK instance by default, so it can run without the ROS 2 robot driver:
 
 ```bash
 ros2 launch flexiv_gripper flexiv_gripper.launch.py robot_sn:=[robot_sn] gripper_name:=Flexiv-GN01
 ```
 
-Or, you can also start the gripper control with the robot driver if the gripper is Flexiv Grav:
+If the robot driver is already running and you want to avoid creating another normal RDK instance, launch the gripper separately with a lite instance:
+
+```bash
+ros2 launch flexiv_gripper flexiv_gripper.launch.py robot_sn:=[robot_sn] gripper_name:=Flexiv-GN01 use_lite_rdk:=true
+```
+
+The lite instance requires another normal RDK instance to already be connected to the robot, for example the one created by the ROS 2 robot driver.
+
+Or, you can also start the gripper control with the robot driver if the gripper is Flexiv Grav. In this path the gripper launch is configured to use a lite RDK instance automatically:
 
 ```bash
 ros2 launch flexiv_bringup rizon.launch.py robot_sn:=[robot_sn] load_gripper:=true

--- a/flexiv_bringup/launch/aico1.launch.py
+++ b/flexiv_bringup/launch/aico1.launch.py
@@ -326,6 +326,7 @@ def generate_launch_description():
             "robot_sn": robot_sn,
             "gripper_name": gripper_name,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper),
     )
@@ -349,6 +350,14 @@ def generate_launch_description():
         )
     )
 
+    # Start gripper only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_launch],
+        )
+    )
+
     # Delay rviz start after `robot_controller_spawner`
     delay_rviz_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -363,8 +372,8 @@ def generate_launch_description():
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
-        load_gripper_launch,
         gpio_controller_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
         delay_rviz_after_robot_controller_spawner,
     ]

--- a/flexiv_bringup/launch/aico1_moveit.launch.py
+++ b/flexiv_bringup/launch/aico1_moveit.launch.py
@@ -389,6 +389,7 @@ def launch_setup(context):
             "robot_sn": robot_sn,
             "gripper_name": gripper_name,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper),
     )
@@ -413,6 +414,14 @@ def launch_setup(context):
         )
     )
 
+    # Start gripper only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_launch],
+        )
+    )
+
     # Delay rviz start after controller
     delay_rviz_after_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -428,8 +437,8 @@ def launch_setup(context):
         joint_state_publisher_node,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
-        load_gripper_launch,
         gpio_controller_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_controller_after_jsb,
         delay_rviz_after_controller,
     ]

--- a/flexiv_bringup/launch/aico2.launch.py
+++ b/flexiv_bringup/launch/aico2.launch.py
@@ -397,6 +397,7 @@ def generate_launch_description():
             "robot_sn": robot_sn_left,
             "gripper_name": gripper_name_left,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_left),
     )
@@ -415,6 +416,7 @@ def generate_launch_description():
             "robot_sn": robot_sn_right,
             "gripper_name": gripper_name_right,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_right),
     )
@@ -449,6 +451,14 @@ def generate_launch_description():
         )
     )
 
+    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+        )
+    )
+
     # Delay right controller start after left controller
     delay_right_controller_after_left_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -474,10 +484,9 @@ def generate_launch_description():
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_left_spawner,
         flexiv_robot_states_broadcaster_right_spawner,
-        load_gripper_left_launch,
-        load_gripper_right_launch,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
         delay_right_controller_after_left_controller,
         delay_rviz_after_right_controller,

--- a/flexiv_bringup/launch/aico2_moveit.launch.py
+++ b/flexiv_bringup/launch/aico2_moveit.launch.py
@@ -459,6 +459,7 @@ def launch_setup(context):
             "gripper_name": gripper_name_left,
             "use_fake_hardware": use_fake_hardware,
             "gripper_node_name": "left_gripper_node",
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_left),
     )
@@ -478,6 +479,7 @@ def launch_setup(context):
             "gripper_name": gripper_name_right,
             "use_fake_hardware": use_fake_hardware,
             "gripper_node_name": "right_gripper_node",
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_right),
     )
@@ -512,6 +514,14 @@ def launch_setup(context):
         )
     )
 
+    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+        )
+    )
+
     # Delay right controller start after left controller
     delay_right_controller_after_left_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -538,10 +548,9 @@ def launch_setup(context):
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_left_spawner,
         flexiv_robot_states_broadcaster_right_spawner,
-        load_gripper_left_launch,
-        load_gripper_right_launch,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
         delay_right_controller_after_left_controller,
         delay_rviz_after_right_controller,

--- a/flexiv_bringup/launch/rizon.launch.py
+++ b/flexiv_bringup/launch/rizon.launch.py
@@ -271,6 +271,7 @@ def generate_launch_description():
             "robot_sn": robot_sn,
             "gripper_name": gripper_name,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper),
     )
@@ -294,6 +295,14 @@ def generate_launch_description():
         )
     )
 
+    # Start gripper only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_launch],
+        )
+    )
+
     # Delay rviz start after `robot_controller_spawner`
     delay_rviz_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -308,8 +317,8 @@ def generate_launch_description():
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
-        load_gripper_launch,
         gpio_controller_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
         delay_rviz_after_robot_controller_spawner,
     ]

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -368,6 +368,7 @@ def generate_launch_description():
             "robot_sn": robot_sn_left,
             "gripper_name": gripper_name_left,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_left),
     )
@@ -386,6 +387,7 @@ def generate_launch_description():
             "robot_sn": robot_sn_right,
             "gripper_name": gripper_name_right,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_right),
     )
@@ -420,6 +422,14 @@ def generate_launch_description():
         )
     )
 
+    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+        )
+    )
+
     # Delay right controller start after left controller
     delay_right_controller_after_left_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -445,10 +455,9 @@ def generate_launch_description():
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_left_spawner,
         flexiv_robot_states_broadcaster_right_spawner,
-        load_gripper_left_launch,
-        load_gripper_right_launch,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
         delay_right_controller_after_left_controller,
         delay_rviz_after_right_controller,

--- a/flexiv_bringup/launch/rizon_dual_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_dual_moveit.launch.py
@@ -416,6 +416,7 @@ def launch_setup(context):
             "gripper_name": gripper_name_left,
             "use_fake_hardware": use_fake_hardware,
             "gripper_node_name": "left_gripper_node",
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_left),
     )
@@ -435,6 +436,7 @@ def launch_setup(context):
             "gripper_name": gripper_name_right,
             "use_fake_hardware": use_fake_hardware,
             "gripper_node_name": "right_gripper_node",
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper_right),
     )
@@ -469,6 +471,14 @@ def launch_setup(context):
         )
     )
 
+    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+        )
+    )
+
     # Delay right controller start after left controller
     delay_right_controller_after_left_controller = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -495,10 +505,9 @@ def launch_setup(context):
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_left_spawner,
         flexiv_robot_states_broadcaster_right_spawner,
-        load_gripper_left_launch,
-        load_gripper_right_launch,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
         delay_right_controller_after_left_controller,
         delay_rviz_after_right_controller,

--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -319,6 +319,7 @@ def launch_setup(context):
             "robot_sn": robot_sn,
             "gripper_name": gripper_name,
             "use_fake_hardware": use_fake_hardware,
+            "use_lite_rdk": "true",
         }.items(),
         condition=IfCondition(load_gripper),
     )
@@ -360,6 +361,14 @@ def launch_setup(context):
         )
     )
 
+    # Start gripper only after ros2_control has activated and the joint state broadcaster is up.
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[load_gripper_launch],
+        )
+    )
+
     # Delay move_group start after `robot_controller_spawner`
     delay_move_group_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -382,9 +391,9 @@ def launch_setup(context):
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
-        load_gripper_launch,
         gpio_controller_spawner,
         servo_node,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
         delay_move_group_after_robot_controller_spawner,
         delay_rviz_after_robot_controller_spawner,

--- a/flexiv_gripper/launch/flexiv_gripper.launch.py
+++ b/flexiv_gripper/launch/flexiv_gripper.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
     robot_sn_param_name = "robot_sn"
     gripper_name_param_name = "gripper_name"
     use_fake_hardware_param_name = "use_fake_hardware"
+    use_lite_rdk_param_name = "use_lite_rdk"
     gripper_joint_names_param_name = "gripper_joint_names"
 
     # Declare arguments
@@ -52,6 +53,14 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
+            use_lite_rdk_param_name,
+            default_value="false",
+            description="Use a lite RDK instance. Requires another normal RDK instance, such as the robot driver, to already be connected.",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
             gripper_joint_names_param_name,
             description="Control joint names of the mounted gripper.",
             default_value="[finger_width_joint]",
@@ -63,6 +72,7 @@ def generate_launch_description():
     robot_sn = LaunchConfiguration(robot_sn_param_name)
     gripper_name = LaunchConfiguration(gripper_name_param_name)
     use_fake_hardware = LaunchConfiguration(use_fake_hardware_param_name)
+    use_lite_rdk = LaunchConfiguration(use_lite_rdk_param_name)
     gripper_joint_names = LaunchConfiguration(gripper_joint_names_param_name)
 
     gripper_config_file = PathJoinSubstitution(
@@ -79,6 +89,7 @@ def generate_launch_description():
                 "robot_sn": robot_sn,
                 "gripper_name": gripper_name,
                 "gripper_joint_names": gripper_joint_names,
+                "use_lite_rdk": use_lite_rdk,
             },
             gripper_config_file,
         ],

--- a/flexiv_gripper/src/gripper_action_server.cpp
+++ b/flexiv_gripper/src/gripper_action_server.cpp
@@ -16,6 +16,7 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
     this->declare_parameter("default_velocity", kDefaultVelocity);
     this->declare_parameter("default_max_force", kDefaultMaxForce);
     this->declare_parameter("gripper_joint_names", std::vector<std::string>());
+    this->declare_parameter("use_lite_rdk", false);
 
     std::string robot_sn;
     if (!this->get_parameter("robot_sn", robot_sn)) {
@@ -37,6 +38,7 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
         this->gripper_joint_names_ = {""};
     }
 
+    const bool use_lite_rdk = this->get_parameter("use_lite_rdk").as_bool();
     const double kStatePublishRate
         = static_cast<double>(this->get_parameter("state_publish_rate").as_int());
     const double kFeedbackPublishRate
@@ -44,32 +46,33 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
     this->future_wait_timeout_ = rclcpp::WallRate(kFeedbackPublishRate).period();
 
     try {
-        RCLCPP_INFO(this->get_logger(), "Connecting to robot %s ...", robot_sn.c_str());
-        robot_ = std::make_unique<flexiv::rdk::Robot>(robot_sn);
+        RCLCPP_INFO(this->get_logger(), "Connecting to robot %s with a %s RDK instance ...",
+            robot_sn.c_str(), use_lite_rdk ? "lite" : "normal");
+        robot_ = std::make_unique<flexiv::rdk::Robot>(
+            robot_sn, std::vector<std::string> {}, true, use_lite_rdk);
 
         RCLCPP_INFO(this->get_logger(), "Successfully connected to robot");
 
-        // Clear fault on robot server if any
-        if (robot_->fault()) {
-            RCLCPP_WARN(this->get_logger(), "Fault occurred on robot server, trying to clear ...");
-            // Try to clear the fault
-            if (!robot_->ClearFault()) {
-                RCLCPP_FATAL(get_logger(), "Fault cannot be cleared, exiting ...");
-                throw std::runtime_error("Fault cannot be cleared");
+        if (!use_lite_rdk) {
+            if (robot_->fault()) {
+                RCLCPP_WARN(
+                    this->get_logger(), "Fault occurred on robot server, trying to clear ...");
+                if (!robot_->ClearFault()) {
+                    RCLCPP_FATAL(get_logger(), "Fault cannot be cleared, exiting ...");
+                    throw std::runtime_error("Fault cannot be cleared");
+                }
+                RCLCPP_INFO(this->get_logger(), "Fault on robot server is cleared");
             }
-            RCLCPP_INFO(this->get_logger(), "Fault on robot server is cleared");
-        }
 
-        // Enable the robot
-        if (!robot_->operational()) {
-            RCLCPP_INFO(this->get_logger(), "Enabling robot ...");
-            robot_->Enable();
+            if (!robot_->operational()) {
+                RCLCPP_INFO(this->get_logger(), "Enabling robot ...");
+                robot_->Enable();
 
-            // Wait for the robot to become operational
-            while (!robot_->operational()) {
-                std::this_thread::sleep_for(std::chrono::seconds(1));
+                while (!robot_->operational()) {
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                }
+                RCLCPP_INFO(this->get_logger(), "Robot is now operational");
             }
-            RCLCPP_INFO(this->get_logger(), "Robot is now operational");
         }
 
         RCLCPP_INFO(this->get_logger(), "Initializing Flexiv gripper control interface");
@@ -94,8 +97,16 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
         // Get the current gripper states
         this->current_gripper_states_ = gripper_->states();
     } catch (const std::exception& e) {
-        RCLCPP_FATAL(this->get_logger(), "%s", e.what());
-        throw e;
+        if (use_lite_rdk) {
+            RCLCPP_FATAL(this->get_logger(),
+                "Failed to start gripper with a lite RDK instance: %s. Ensure the robot driver "
+                "is already running with a normal RDK connection, or relaunch the gripper with "
+                "parameter 'use_lite_rdk:=false' for standalone operation.",
+                e.what());
+        } else {
+            RCLCPP_FATAL(this->get_logger(), "%s", e.what());
+        }
+        throw;
     }
 
     // Create the stop service server


### PR DESCRIPTION
This pull request improves the integration and startup sequence of the Flexiv gripper in various ROS 2 launch files. The main focus is to ensure the gripper nodes are started only after the robot's joint state broadcaster is active, and to add support for launching the gripper with a "lite" RDK instance when appropriate, and fixes issue #95 

**Gripper Launch Sequencing Improvements:**
* Added logic to delay the start of the gripper nodes until after the `joint_state_broadcaster_spawner` process exits, ensuring that `ros2_control` is fully activated before the gripper is launched. This is implemented across all relevant single and dual-arm launch files, including both standard and MoveIt variants.

**Support for Lite RDK Instance:**
* Added the `use_lite_rdk` launch argument to all gripper launch invocations, allowing the gripper node to connect via a lite RDK instance when the main robot driver is already running. This reduces resource usage and avoids redundant RDK instances.