### PR TITLE
Bugfix/Update bringup launch files startup sequence

### DIFF
--- a/flexiv_bringup/launch/aico1.launch.py
+++ b/flexiv_bringup/launch/aico1.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     RegisterEventHandler,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -158,6 +160,15 @@ def generate_launch_description():
     external_axis_type = LaunchConfiguration(external_axis_type_param_name)
     external_axis_prefix = LaunchConfiguration(external_axis_prefix_param_name)
     arm_prefix = LaunchConfiguration(arm_prefix_param_name)
+    gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
@@ -331,6 +342,22 @@ def generate_launch_description():
         condition=IfCondition(load_gripper),
     )
 
+    gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_gripper_ready",
+        parameters=[{"ready_topic": "/flexiv_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    def launch_robot_controller_after_gripper_ready(event, context):
+        if event.returncode == 0:
+            return [robot_controller_spawner]
+        return [
+            EmitEvent(event=Shutdown(reason="flexiv_gripper_node did not report ready"))
+        ]
+
     # Run gpio controller
     gpio_controller_spawner = Node(
         package="controller_manager",
@@ -346,7 +373,8 @@ def generate_launch_description():
             event_handler=OnProcessExit(
                 target_action=joint_state_broadcaster_spawner,
                 on_exit=[robot_controller_spawner],
-            )
+            ),
+            condition=UnlessCondition(gripper_ready_gate_condition),
         )
     )
 
@@ -355,7 +383,16 @@ def generate_launch_description():
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[load_gripper_launch],
-        )
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    delay_robot_controller_spawner_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=gripper_ready_waiter,
+            on_exit=launch_robot_controller_after_gripper_ready,
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
     )
 
     # Delay rviz start after `robot_controller_spawner`
@@ -370,11 +407,13 @@ def generate_launch_description():
         ros2_control_node,
         joint_state_publisher_node,
         robot_state_publisher_node,
+        gripper_ready_waiter,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
         gpio_controller_spawner,
         delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_robot_controller_spawner_after_gripper_ready,
         delay_rviz_after_robot_controller_spawner,
     ]
 

--- a/flexiv_bringup/launch/aico1_moveit.launch.py
+++ b/flexiv_bringup/launch/aico1_moveit.launch.py
@@ -4,12 +4,14 @@ import os
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     OpaqueFunction,
     RegisterEventHandler,
     SetLaunchConfiguration,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -57,6 +59,15 @@ def launch_setup(context):
     external_axis_type = LaunchConfiguration("external_axis_type")
     external_axis_prefix = LaunchConfiguration("external_axis_prefix")
     arm_prefix = LaunchConfiguration("arm_prefix")
+    gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     robot_sn_str = robot_sn.perform(context)
     arm_prefix_str = arm_prefix.perform(context)
@@ -394,6 +405,22 @@ def launch_setup(context):
         condition=IfCondition(load_gripper),
     )
 
+    gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_gripper_ready",
+        parameters=[{"ready_topic": "/flexiv_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    def launch_controller_after_gripper_ready(event, context):
+        if event.returncode == 0:
+            return [rizon_arm_controller_spawner]
+        return [
+            EmitEvent(event=Shutdown(reason="flexiv_gripper_node did not report ready"))
+        ]
+
     # Run gpio controller
     gpio_controller_spawner = Node(
         package="controller_manager",
@@ -411,7 +438,8 @@ def launch_setup(context):
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[rizon_arm_controller_spawner],
-        )
+        ),
+        condition=UnlessCondition(gripper_ready_gate_condition),
     )
 
     # Start gripper only after ros2_control has activated and the joint state broadcaster is up.
@@ -419,7 +447,16 @@ def launch_setup(context):
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[load_gripper_launch],
-        )
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    delay_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready,
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
     )
 
     # Delay rviz start after controller
@@ -435,11 +472,13 @@ def launch_setup(context):
         robot_state_publisher_node,
         ros2_control_node,
         joint_state_publisher_node,
+        gripper_ready_waiter,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
         gpio_controller_spawner,
         delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_controller_after_jsb,
+        delay_controller_after_gripper_ready,
         delay_rviz_after_controller,
     ]
 

--- a/flexiv_bringup/launch/aico2.launch.py
+++ b/flexiv_bringup/launch/aico2.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     RegisterEventHandler,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -180,6 +182,24 @@ def generate_launch_description():
     )
     external_axis_type = LaunchConfiguration(external_axis_type_param_name)
     external_axis_prefix = LaunchConfiguration(external_axis_prefix_param_name)
+    left_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_left,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
+    right_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_right,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     # Construct prefixes
     from launch.actions import SetLaunchConfiguration
@@ -421,6 +441,36 @@ def generate_launch_description():
         condition=IfCondition(load_gripper_right),
     )
 
+    left_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_left_gripper_ready",
+        parameters=[{"ready_topic": "/left_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(left_gripper_ready_gate_condition),
+    )
+
+    right_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_right_gripper_ready",
+        parameters=[{"ready_topic": "/right_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    def launch_controller_after_gripper_ready(controller_spawner, gripper_node_name):
+        def handle_gripper_ready(event, context):
+            if event.returncode == 0:
+                return [controller_spawner]
+            return [
+                EmitEvent(
+                    event=Shutdown(reason=f"{gripper_node_name} did not report ready")
+                )
+            ]
+
+        return handle_gripper_ready
+
     # Run gpio controllers
     gpio_controller_left_spawner = Node(
         package="controller_manager",
@@ -448,15 +498,38 @@ def generate_launch_description():
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[left_rizon_arm_controller_spawner],
+        ),
+        condition=UnlessCondition(left_gripper_ready_gate_condition),
+    )
+
+    delay_left_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_left_launch, left_gripper_ready_waiter],
+            ),
+            condition=IfCondition(left_gripper_ready_gate_condition),
         )
     )
 
-    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
-    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+    delay_right_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_right_launch],
+            ),
+            condition=IfCondition(right_gripper_ready_gate_condition),
         )
+    )
+
+    delay_left_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                left_rizon_arm_controller_spawner, "left_gripper_node"
+            ),
+        ),
+        condition=IfCondition(left_gripper_ready_gate_condition),
     )
 
     # Delay right controller start after left controller
@@ -464,7 +537,26 @@ def generate_launch_description():
         event_handler=OnProcessExit(
             target_action=left_rizon_arm_controller_spawner,
             on_exit=[right_rizon_arm_controller_spawner],
-        )
+        ),
+        condition=UnlessCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_gripper_ready_waiter_after_left_controller = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_rizon_arm_controller_spawner,
+            on_exit=[right_gripper_ready_waiter],
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=right_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                right_rizon_arm_controller_spawner, "right_gripper_node"
+            ),
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
     )
 
     # Delay rviz start after right controller
@@ -486,9 +578,13 @@ def generate_launch_description():
         flexiv_robot_states_broadcaster_right_spawner,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
-        delay_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_left_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_right_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
+        delay_left_controller_after_gripper_ready,
         delay_right_controller_after_left_controller,
+        delay_right_gripper_ready_waiter_after_left_controller,
+        delay_right_controller_after_gripper_ready,
         delay_rviz_after_right_controller,
     ]
 

--- a/flexiv_bringup/launch/aico2_moveit.launch.py
+++ b/flexiv_bringup/launch/aico2_moveit.launch.py
@@ -4,12 +4,14 @@ import os
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     OpaqueFunction,
     RegisterEventHandler,
     SetLaunchConfiguration,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -64,6 +66,24 @@ def launch_setup(context):
 
     load_mounted_ft_sensor_left = LaunchConfiguration("load_mounted_ft_sensor_left")
     load_mounted_ft_sensor_right = LaunchConfiguration("load_mounted_ft_sensor_right")
+    left_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_left,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
+    right_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_right,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     external_axis_type = LaunchConfiguration("external_axis_type")
     external_axis_prefix = LaunchConfiguration("external_axis_prefix")
@@ -484,6 +504,36 @@ def launch_setup(context):
         condition=IfCondition(load_gripper_right),
     )
 
+    left_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_left_gripper_ready",
+        parameters=[{"ready_topic": "/left_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(left_gripper_ready_gate_condition),
+    )
+
+    right_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_right_gripper_ready",
+        parameters=[{"ready_topic": "/right_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    def launch_controller_after_gripper_ready(controller_spawner, gripper_node_name):
+        def handle_gripper_ready(event, context):
+            if event.returncode == 0:
+                return [controller_spawner]
+            return [
+                EmitEvent(
+                    event=Shutdown(reason=f"{gripper_node_name} did not report ready")
+                )
+            ]
+
+        return handle_gripper_ready
+
     # Run gpio controllers
     gpio_controller_left_spawner = Node(
         package="controller_manager",
@@ -511,15 +561,38 @@ def launch_setup(context):
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[left_rizon_arm_controller_spawner],
+        ),
+        condition=UnlessCondition(left_gripper_ready_gate_condition),
+    )
+
+    delay_left_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_left_launch, left_gripper_ready_waiter],
+            ),
+            condition=IfCondition(left_gripper_ready_gate_condition),
         )
     )
 
-    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
-    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+    delay_right_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_right_launch],
+            ),
+            condition=IfCondition(right_gripper_ready_gate_condition),
         )
+    )
+
+    delay_left_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                left_rizon_arm_controller_spawner, "left_gripper_node"
+            ),
+        ),
+        condition=IfCondition(left_gripper_ready_gate_condition),
     )
 
     # Delay right controller start after left controller
@@ -527,7 +600,26 @@ def launch_setup(context):
         event_handler=OnProcessExit(
             target_action=left_rizon_arm_controller_spawner,
             on_exit=[right_rizon_arm_controller_spawner],
-        )
+        ),
+        condition=UnlessCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_gripper_ready_waiter_after_left_controller = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_rizon_arm_controller_spawner,
+            on_exit=[right_gripper_ready_waiter],
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=right_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                right_rizon_arm_controller_spawner, "right_gripper_node"
+            ),
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
     )
 
     # Delay rviz start after right controller
@@ -550,9 +642,13 @@ def launch_setup(context):
         flexiv_robot_states_broadcaster_right_spawner,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
-        delay_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_left_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_right_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
+        delay_left_controller_after_gripper_ready,
         delay_right_controller_after_left_controller,
+        delay_right_gripper_ready_waiter_after_left_controller,
+        delay_right_controller_after_gripper_ready,
         delay_rviz_after_right_controller,
     ]
 

--- a/flexiv_bringup/launch/rizon.launch.py
+++ b/flexiv_bringup/launch/rizon.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     RegisterEventHandler,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -15,6 +17,7 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 
 
@@ -126,6 +129,15 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration(use_fake_hardware_param_name)
     fake_sensor_commands = LaunchConfiguration(fake_sensor_commands_param_name)
     robot_controller = LaunchConfiguration(robot_controller_param_name)
+    gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
@@ -276,6 +288,22 @@ def generate_launch_description():
         condition=IfCondition(load_gripper),
     )
 
+    gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_gripper_ready",
+        parameters=[{"ready_topic": "/flexiv_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    def launch_robot_controller_after_gripper_ready(event, context):
+        if event.returncode == 0:
+            return [robot_controller_spawner]
+        return [
+            EmitEvent(event=Shutdown(reason="flexiv_gripper_node did not report ready"))
+        ]
+
     # Run gpio controller
     gpio_controller_spawner = Node(
         package="controller_manager",
@@ -291,7 +319,8 @@ def generate_launch_description():
             event_handler=OnProcessExit(
                 target_action=joint_state_broadcaster_spawner,
                 on_exit=[robot_controller_spawner],
-            )
+            ),
+            condition=UnlessCondition(gripper_ready_gate_condition),
         )
     )
 
@@ -300,7 +329,16 @@ def generate_launch_description():
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[load_gripper_launch],
-        )
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    delay_robot_controller_spawner_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=gripper_ready_waiter,
+            on_exit=launch_robot_controller_after_gripper_ready,
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
     )
 
     # Delay rviz start after `robot_controller_spawner`
@@ -315,11 +353,13 @@ def generate_launch_description():
         ros2_control_node,
         joint_state_publisher_node,
         robot_state_publisher_node,
+        gripper_ready_waiter,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
         gpio_controller_spawner,
         delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_robot_controller_spawner_after_gripper_ready,
         delay_rviz_after_robot_controller_spawner,
     ]
 

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     RegisterEventHandler,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -169,6 +171,24 @@ def generate_launch_description():
     )
     load_mounted_ft_sensor_right = LaunchConfiguration(
         load_mounted_ft_sensor_right_param_name
+    )
+    left_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_left,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
+    right_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_right,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
     )
 
     # Construct prefixes
@@ -392,6 +412,36 @@ def generate_launch_description():
         condition=IfCondition(load_gripper_right),
     )
 
+    left_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_left_gripper_ready",
+        parameters=[{"ready_topic": "/left_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(left_gripper_ready_gate_condition),
+    )
+
+    right_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_right_gripper_ready",
+        parameters=[{"ready_topic": "/right_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    def launch_controller_after_gripper_ready(controller_spawner, gripper_node_name):
+        def handle_gripper_ready(event, context):
+            if event.returncode == 0:
+                return [controller_spawner]
+            return [
+                EmitEvent(
+                    event=Shutdown(reason=f"{gripper_node_name} did not report ready")
+                )
+            ]
+
+        return handle_gripper_ready
+
     # Run gpio controllers
     gpio_controller_left_spawner = Node(
         package="controller_manager",
@@ -419,15 +469,38 @@ def generate_launch_description():
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[left_rizon_arm_controller_spawner],
+        ),
+        condition=UnlessCondition(left_gripper_ready_gate_condition),
+    )
+
+    delay_left_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_left_launch, left_gripper_ready_waiter],
+            ),
+            condition=IfCondition(left_gripper_ready_gate_condition),
         )
     )
 
-    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
-    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+    delay_right_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_right_launch],
+            ),
+            condition=IfCondition(right_gripper_ready_gate_condition),
         )
+    )
+
+    delay_left_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                left_rizon_arm_controller_spawner, "left_gripper_node"
+            ),
+        ),
+        condition=IfCondition(left_gripper_ready_gate_condition),
     )
 
     # Delay right controller start after left controller
@@ -435,7 +508,26 @@ def generate_launch_description():
         event_handler=OnProcessExit(
             target_action=left_rizon_arm_controller_spawner,
             on_exit=[right_rizon_arm_controller_spawner],
-        )
+        ),
+        condition=UnlessCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_gripper_ready_waiter_after_left_controller = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_rizon_arm_controller_spawner,
+            on_exit=[right_gripper_ready_waiter],
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=right_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                right_rizon_arm_controller_spawner, "right_gripper_node"
+            ),
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
     )
 
     # Delay rviz start after right controller
@@ -457,9 +549,13 @@ def generate_launch_description():
         flexiv_robot_states_broadcaster_right_spawner,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
-        delay_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_left_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_right_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
+        delay_left_controller_after_gripper_ready,
         delay_right_controller_after_left_controller,
+        delay_right_gripper_ready_waiter_after_left_controller,
+        delay_right_controller_after_gripper_ready,
         delay_rviz_after_right_controller,
     ]
 

--- a/flexiv_bringup/launch/rizon_dual_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_dual_moveit.launch.py
@@ -5,12 +5,14 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     OpaqueFunction,
     RegisterEventHandler,
     SetLaunchConfiguration,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -65,6 +67,24 @@ def launch_setup(context):
 
     load_mounted_ft_sensor_left = LaunchConfiguration("load_mounted_ft_sensor_left")
     load_mounted_ft_sensor_right = LaunchConfiguration("load_mounted_ft_sensor_right")
+    left_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_left,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
+    right_gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper_right,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     warehouse_sqlite_path = LaunchConfiguration("warehouse_sqlite_path")
 
@@ -441,6 +461,36 @@ def launch_setup(context):
         condition=IfCondition(load_gripper_right),
     )
 
+    left_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_left_gripper_ready",
+        parameters=[{"ready_topic": "/left_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(left_gripper_ready_gate_condition),
+    )
+
+    right_gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_right_gripper_ready",
+        parameters=[{"ready_topic": "/right_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    def launch_controller_after_gripper_ready(controller_spawner, gripper_node_name):
+        def handle_gripper_ready(event, context):
+            if event.returncode == 0:
+                return [controller_spawner]
+            return [
+                EmitEvent(
+                    event=Shutdown(reason=f"{gripper_node_name} did not report ready")
+                )
+            ]
+
+        return handle_gripper_ready
+
     # Run gpio controllers
     gpio_controller_left_spawner = Node(
         package="controller_manager",
@@ -468,15 +518,38 @@ def launch_setup(context):
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[left_rizon_arm_controller_spawner],
+        ),
+        condition=UnlessCondition(left_gripper_ready_gate_condition),
+    )
+
+    delay_left_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_left_launch, left_gripper_ready_waiter],
+            ),
+            condition=IfCondition(left_gripper_ready_gate_condition),
         )
     )
 
-    # Start grippers only after ros2_control has activated and the joint state broadcaster is up.
-    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[load_gripper_left_launch, load_gripper_right_launch],
+    delay_right_gripper_launch_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[load_gripper_right_launch],
+            ),
+            condition=IfCondition(right_gripper_ready_gate_condition),
         )
+    )
+
+    delay_left_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                left_rizon_arm_controller_spawner, "left_gripper_node"
+            ),
+        ),
+        condition=IfCondition(left_gripper_ready_gate_condition),
     )
 
     # Delay right controller start after left controller
@@ -484,7 +557,26 @@ def launch_setup(context):
         event_handler=OnProcessExit(
             target_action=left_rizon_arm_controller_spawner,
             on_exit=[right_rizon_arm_controller_spawner],
-        )
+        ),
+        condition=UnlessCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_gripper_ready_waiter_after_left_controller = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=left_rizon_arm_controller_spawner,
+            on_exit=[right_gripper_ready_waiter],
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
+    )
+
+    delay_right_controller_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=right_gripper_ready_waiter,
+            on_exit=launch_controller_after_gripper_ready(
+                right_rizon_arm_controller_spawner, "right_gripper_node"
+            ),
+        ),
+        condition=IfCondition(right_gripper_ready_gate_condition),
     )
 
     # Delay rviz start after right controller
@@ -507,9 +599,13 @@ def launch_setup(context):
         flexiv_robot_states_broadcaster_right_spawner,
         gpio_controller_left_spawner,
         gpio_controller_right_spawner,
-        delay_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_left_gripper_launch_after_joint_state_broadcaster_spawner,
+        delay_right_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_left_controller_after_jsb,
+        delay_left_controller_after_gripper_ready,
         delay_right_controller_after_left_controller,
+        delay_right_gripper_ready_waiter_after_left_controller,
+        delay_right_controller_after_gripper_ready,
         delay_rviz_after_right_controller,
     ]
 

--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -5,12 +5,13 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     IncludeLaunchDescription,
     OpaqueFunction,
     RegisterEventHandler,
-    TimerAction,
 )
 from launch.conditions import IfCondition, UnlessCondition
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
@@ -21,6 +22,7 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 
 
@@ -57,6 +59,15 @@ def launch_setup(context):
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     warehouse_sqlite_path = LaunchConfiguration("warehouse_sqlite_path")
     start_servo = LaunchConfiguration("start_servo")
+    gripper_ready_gate_condition = PythonExpression(
+        [
+            "'",
+            load_gripper,
+            "'.lower() in ['true', '1'] and '",
+            use_fake_hardware,
+            "'.lower() not in ['true', '1']",
+        ]
+    )
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
@@ -332,6 +343,22 @@ def launch_setup(context):
         condition=IfCondition(load_gripper),
     )
 
+    gripper_ready_waiter = Node(
+        package="flexiv_gripper",
+        executable="wait_for_gripper_ready",
+        name="wait_for_gripper_ready",
+        parameters=[{"ready_topic": "/flexiv_gripper_node/ready"}],
+        output="screen",
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    def launch_robot_controller_after_gripper_ready(event, context):
+        if event.returncode == 0:
+            return [robot_controller_spawner]
+        return [
+            EmitEvent(event=Shutdown(reason="flexiv_gripper_node did not report ready"))
+        ]
+
     # Servo node for realtime control
     servo_yaml = load_yaml(
         "flexiv_moveit_config",
@@ -368,24 +395,24 @@ def launch_setup(context):
                 target_action=joint_state_broadcaster_spawner,
                 on_exit=[robot_controller_spawner],
             ),
-            condition=UnlessCondition(load_gripper),
+            condition=UnlessCondition(gripper_ready_gate_condition),
         )
     )
 
-    # When gripper is loaded, start gripper after joint_state_broadcaster,
-    # then delay robot_controller start to give flexiv_gripper_node time to initialize.
-    delay_robot_controller_spawner_after_gripper_init = RegisterEventHandler(
+    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
-            on_exit=[
-                load_gripper_launch,
-                TimerAction(
-                    period=12.0,
-                    actions=[robot_controller_spawner],
-                ),
-            ],
+            on_exit=[load_gripper_launch],
         ),
-        condition=IfCondition(load_gripper),
+        condition=IfCondition(gripper_ready_gate_condition),
+    )
+
+    delay_robot_controller_spawner_after_gripper_ready = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=gripper_ready_waiter,
+            on_exit=launch_robot_controller_after_gripper_ready,
+        ),
+        condition=IfCondition(gripper_ready_gate_condition),
     )
 
     # Delay move_group start after `robot_controller_spawner`
@@ -408,12 +435,14 @@ def launch_setup(context):
         ros2_control_node,
         joint_state_publisher_node,
         robot_state_publisher_node,
+        gripper_ready_waiter,
         joint_state_broadcaster_spawner,
         flexiv_robot_states_broadcaster_spawner,
         gpio_controller_spawner,
         servo_node,
+        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_gripper_init,
+        delay_robot_controller_spawner_after_gripper_ready,
         delay_move_group_after_robot_controller_spawner,
         delay_rviz_after_robot_controller_spawner,
     ]

--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -8,6 +8,7 @@ from launch.actions import (
     IncludeLaunchDescription,
     OpaqueFunction,
     RegisterEventHandler,
+    TimerAction,
 )
 from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit
@@ -23,7 +24,7 @@ from launch.substitutions import (
 )
 
 
-def load_yaml(package_name, file_path, robot_sn=""):
+def load_yaml(package_name, file_path, replacements=None):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
@@ -31,9 +32,9 @@ def load_yaml(package_name, file_path, robot_sn=""):
         with open(absolute_file_path, "r") as file:
             yaml_content = file.read()
 
-        if robot_sn:
-            # Replace variable placeholder with actual robot_sn
-            yaml_content = yaml_content.replace("$(var robot_sn)", robot_sn)
+        if replacements:
+            for placeholder, replacement in replacements.items():
+                yaml_content = yaml_content.replace(placeholder, replacement)
 
         return yaml.safe_load(yaml_content)
     except (
@@ -133,9 +134,14 @@ def launch_setup(context):
 
     publish_robot_description_semantic = {"publish_robot_description_semantic": True}
 
-    robot_description_kinematics = PathJoinSubstitution(
-        [FindPackageShare("flexiv_moveit_config"), "config", "kinematics.yaml"]
+    replacements = {"$(var robot_sn)": robot_sn_str}
+
+    robot_description_kinematics_yaml = load_yaml(
+        "flexiv_moveit_config", "config/kinematics.yaml", replacements
     )
+    robot_description_kinematics = {
+        "robot_description_kinematics": robot_description_kinematics_yaml
+    }
 
     # Planning Configuration
     ompl_planning_pipeline_config = {
@@ -150,12 +156,14 @@ def launch_setup(context):
             "start_state_max_bounds_error": 0.1,
         }
     }
-    ompl_planning_yaml = load_yaml("flexiv_moveit_config", "config/ompl_planning.yaml")
+    ompl_planning_yaml = load_yaml(
+        "flexiv_moveit_config", "config/ompl_planning.yaml", replacements
+    )
     ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     # Trajectory Execution Configuration
     moveit_simple_controllers_yaml = load_yaml(
-        "flexiv_moveit_config", "config/moveit_controllers.yaml", robot_sn_str
+        "flexiv_moveit_config", "config/moveit_controllers.yaml", replacements
     )
 
     moveit_controllers = {
@@ -179,7 +187,7 @@ def launch_setup(context):
 
     joint_limits_yaml = {
         "robot_description_planning": load_yaml(
-            "flexiv_moveit_config", "config/joint_limits.yaml", robot_sn_str
+            "flexiv_moveit_config", "config/joint_limits.yaml", replacements
         )
     }
 
@@ -326,7 +334,9 @@ def launch_setup(context):
 
     # Servo node for realtime control
     servo_yaml = load_yaml(
-        "flexiv_moveit_config", "config/rizon_moveit_servo_config.yaml", robot_sn_str
+        "flexiv_moveit_config",
+        "config/rizon_moveit_servo_config.yaml",
+        replacements,
     )
     servo_params = {"moveit_servo": servo_yaml}
     servo_node = Node(
@@ -351,22 +361,31 @@ def launch_setup(context):
         condition=UnlessCondition(use_fake_hardware),
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
+    # Delay start of robot_controller after `joint_state_broadcaster` when gripper is not loaded
     delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = (
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=joint_state_broadcaster_spawner,
                 on_exit=[robot_controller_spawner],
-            )
+            ),
+            condition=UnlessCondition(load_gripper),
         )
     )
 
-    # Start gripper only after ros2_control has activated and the joint state broadcaster is up.
-    delay_gripper_launch_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # When gripper is loaded, start gripper after joint_state_broadcaster,
+    # then delay robot_controller start to give flexiv_gripper_node time to initialize.
+    delay_robot_controller_spawner_after_gripper_init = RegisterEventHandler(
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
-            on_exit=[load_gripper_launch],
-        )
+            on_exit=[
+                load_gripper_launch,
+                TimerAction(
+                    period=12.0,
+                    actions=[robot_controller_spawner],
+                ),
+            ],
+        ),
+        condition=IfCondition(load_gripper),
     )
 
     # Delay move_group start after `robot_controller_spawner`
@@ -393,8 +412,8 @@ def launch_setup(context):
         flexiv_robot_states_broadcaster_spawner,
         gpio_controller_spawner,
         servo_node,
-        delay_gripper_launch_after_joint_state_broadcaster_spawner,
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_robot_controller_spawner_after_gripper_init,
         delay_move_group_after_robot_controller_spawner,
         delay_rviz_after_robot_controller_spawner,
     ]

--- a/flexiv_gripper/CMakeLists.txt
+++ b/flexiv_gripper/CMakeLists.txt
@@ -20,12 +20,16 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(flexiv_rdk REQUIRED)
 
 add_library(gripper_action_server
   SHARED
   src/gripper_action_server.cpp)
+
+add_executable(wait_for_gripper_ready
+  src/wait_for_gripper_ready.cpp)
 
 target_include_directories(gripper_action_server PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -41,7 +45,12 @@ ament_target_dependencies(gripper_action_server
   rclcpp_action
   rclcpp_components
   sensor_msgs
+  std_msgs
   std_srvs)
+
+ament_target_dependencies(wait_for_gripper_ready
+  rclcpp
+  std_msgs)
 
 rclcpp_components_register_node(gripper_action_server
   PLUGIN "flexiv_gripper::GripperActionServer"
@@ -51,6 +60,9 @@ install(TARGETS gripper_action_server
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
+
+install(TARGETS wait_for_gripper_ready
+  DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME}/)

--- a/flexiv_gripper/include/flexiv_gripper/gripper_action_server.hpp
+++ b/flexiv_gripper/include/flexiv_gripper/gripper_action_server.hpp
@@ -21,6 +21,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
 // Flexiv
@@ -112,6 +113,7 @@ private:
     std::chrono::nanoseconds future_wait_timeout_ {0};
 
     // Gripper joint states publisher
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr gripper_ready_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr gripper_joint_states_publisher_;
     std::vector<std::string> gripper_joint_names_;
 

--- a/flexiv_gripper/package.xml
+++ b/flexiv_gripper/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/flexiv_gripper/src/gripper_action_server.cpp
+++ b/flexiv_gripper/src/gripper_action_server.cpp
@@ -44,6 +44,8 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
     const double kFeedbackPublishRate
         = static_cast<double>(this->get_parameter("feedback_publish_rate").as_int());
     this->future_wait_timeout_ = rclcpp::WallRate(kFeedbackPublishRate).period();
+    this->gripper_ready_publisher_ = this->create_publisher<std_msgs::msg::Bool>(
+        "~/ready", rclcpp::QoS(1).reliable().transient_local());
 
     try {
         RCLCPP_INFO(this->get_logger(), "Connecting to robot %s with a %s RDK instance ...",
@@ -152,6 +154,11 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
         = this->create_publisher<sensor_msgs::msg::JointState>("~/gripper_joint_states", 1);
     this->state_publish_timer_ = this->create_wall_timer(
         rclcpp::WallRate(kStatePublishRate).period(), [this]() { return PublishGripperStates(); });
+
+    auto ready_msg = std_msgs::msg::Bool();
+    ready_msg.data = true;
+    this->gripper_ready_publisher_->publish(ready_msg);
+    RCLCPP_INFO(this->get_logger(), "Published gripper readiness on ~/ready");
 }
 
 rclcpp_action::CancelResponse GripperActionServer::HandleCancel(GripperAction action)

--- a/flexiv_gripper/src/wait_for_gripper_ready.cpp
+++ b/flexiv_gripper/src/wait_for_gripper_ready.cpp
@@ -1,0 +1,82 @@
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
+
+namespace flexiv_gripper {
+
+class WaitForGripperReady : public rclcpp::Node
+{
+public:
+    WaitForGripperReady()
+    : Node("wait_for_gripper_ready")
+    {
+        this->declare_parameter("ready_topic", std::string("/flexiv_gripper_node/ready"));
+        this->declare_parameter("timeout_sec", 30.0);
+
+        ready_topic_ = this->get_parameter("ready_topic").as_string();
+        const double timeout_sec = this->get_parameter("timeout_sec").as_double();
+        if (timeout_sec <= 0.0) {
+            throw std::invalid_argument("Parameter 'timeout_sec' must be positive");
+        }
+
+        timeout_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::duration<double>(timeout_sec));
+
+        readiness_subscription_ = this->create_subscription<std_msgs::msg::Bool>(ready_topic_,
+            rclcpp::QoS(1).reliable().transient_local(),
+            [this](const std_msgs::msg::Bool::SharedPtr msg) {
+                if (ready_ || !msg->data) {
+                    return;
+                }
+
+                ready_ = true;
+                exit_code_ = 0;
+                RCLCPP_INFO(
+                    this->get_logger(), "Received gripper readiness on %s", ready_topic_.c_str());
+                rclcpp::shutdown();
+            });
+
+        timeout_timer_ = this->create_wall_timer(timeout_, [this]() {
+            if (ready_) {
+                return;
+            }
+
+            RCLCPP_ERROR(this->get_logger(), "Timed out waiting for gripper readiness on %s",
+                ready_topic_.c_str());
+            rclcpp::shutdown();
+        });
+
+        RCLCPP_INFO(this->get_logger(), "Waiting up to %.1f seconds for gripper readiness on %s",
+            std::chrono::duration<double>(timeout_).count(), ready_topic_.c_str());
+    }
+
+    int exit_code() const { return exit_code_; }
+
+private:
+    std::string ready_topic_;
+    bool ready_ {false};
+    int exit_code_ {1};
+    std::chrono::nanoseconds timeout_ {std::chrono::seconds(30)};
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr readiness_subscription_;
+    rclcpp::TimerBase::SharedPtr timeout_timer_;
+};
+
+} // namespace flexiv_gripper
+
+int main(int argc, char* argv[])
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<flexiv_gripper::WaitForGripperReady>();
+    rclcpp::spin(node);
+
+    const auto exit_code = node->exit_code();
+    if (rclcpp::ok()) {
+        rclcpp::shutdown();
+    }
+
+    return exit_code;
+}

--- a/flexiv_moveit_config/config/kinematics.yaml
+++ b/flexiv_moveit_config/config/kinematics.yaml
@@ -1,7 +1,4 @@
-/**:
-  ros__parameters:
-    robot_description_kinematics:
-      rizon_arm:
-        kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-        kinematics_solver_search_resolution: 0.005
-        kinematics_solver_timeout: 0.05
+$(var robot_sn)_arm:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.05

--- a/flexiv_moveit_config/config/ompl_planning.yaml
+++ b/flexiv_moveit_config/config/ompl_planning.yaml
@@ -122,7 +122,7 @@ planner_configs:
     max_failures: 5000 # maximum consecutive failure limit. default: 5000
   TrajOptDefault:
     type: geometric::TrajOpt
-rizon_arm:
+$(var robot_sn)_arm:
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -148,7 +148,7 @@ rizon_arm:
     - SPARSkConfigDefault
     - SPARStwokConfigDefault
     - TrajOptDefault
-grav_gripper:
+$(var robot_sn)_grav_gripper:
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault


### PR DESCRIPTION
This pull request fixes issue #95 and introduces a more robust, flexible startup sequence for the Flexiv robot launch files, ensuring that arm controllers start only after the associated gripper nodes are fully ready. It adds explicit "wait for gripper ready" nodes and event-driven logic to handle gripper readiness, with improved error handling and support for both single- and dual-arm configurations. The changes help prevent race conditions and startup failures when using real hardware, especially in complex setups. 

**Gripper readiness gating and sequencing:**

- Introduced `gripper_ready_waiter` nodes (and their left/right variants) in all relevant launch files. These nodes wait for gripper nodes to signal readiness before allowing arm controllers to start, preventing premature controller initialization.
- Added Python expressions (`gripper_ready_gate_condition`, `left_gripper_ready_gate_condition`, `right_gripper_ready_gate_condition`) to conditionally enable the gripper readiness gating logic only when real hardware is used, and the gripper is enabled.

**Event-driven controller launch and error handling:**

- Modified event handler logic so that arm controllers are only launched after the gripper is confirmed ready, using `OnProcessExit` and custom handler functions. If the gripper node fails to report ready, the launch process is cleanly shut down with an informative error message.
- Updated event handler registration to distinguish between cases where gripper gating is active or not, ensuring correct sequencing in both hardware and simulation scenarios.

The resulting behaviour is now explicit:
1. Single-arm, no real gripper: `controller_manager -> joint_state_broadcaster -> controller`.
2. Single-arm, real gripper: `controller_manager -> joint_state_broadcaster -> gripper launch + waiter -> controller`.
3. Dual-arm left/right false: left controller starts from JSB, right controller still waits for left-controller sequencing.
4. Dual-arm left/right true: each side uses its own readiness gate, and the right side still stays chained after the left-controller step.