### PR TITLE
Release/Flexiv ROS 2 Humble v1.9.1

### DIFF
--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build and install flexiv_drdk
         shell: bash
         run: |
-          git clone --branch v1.2 --depth 1 https://github.com/flexivrobotics/flexiv_drdk.git
+          git clone --branch v1.2.1 --depth 1 https://github.com/flexivrobotics/flexiv_drdk.git
           cd flexiv_drdk/thirdparty
           source /opt/ros/humble/setup.bash
           bash build_and_install_dependencies.sh ~/flexiv_install

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -18,10 +18,11 @@ jobs:
     strategy:
       fail-fast: false
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       ROS_DISTRO: humble
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install dependencies
@@ -44,7 +45,7 @@ jobs:
       - name: Build and install flexiv_rdk
         shell: bash
         run: |
-          git clone --branch v1.9 --depth 1 https://github.com/flexivrobotics/flexiv_rdk.git
+          git clone --branch v1.9.1 --depth 1 https://github.com/flexivrobotics/flexiv_rdk.git
           cd flexiv_rdk/thirdparty
           source /opt/ros/humble/setup.bash
           bash build_and_install_dependencies_not_in_ros2.sh ~/flexiv_install

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you are using a Flexiv dual robot setup, you can install `flexiv_drdk` as wel
 
    ```bash
    cd ~/flexiv_ros2_ws/src
-   git clone --branch v1.2 --depth 1 https://github.com/flexivrobotics/flexiv_drdk.git
+   git clone --branch v1.2.1 --depth 1 https://github.com/flexivrobotics/flexiv_drdk.git
    touch flexiv_drdk/COLCON_IGNORE
    ```
 

--- a/flexiv.humble.repos
+++ b/flexiv.humble.repos
@@ -6,4 +6,4 @@ repositories:
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git
-    version: v1.9
+    version: v1.9.1

--- a/flexiv_bringup/package.xml
+++ b/flexiv_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_bringup</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>Package with launch files and run-time configurations for Flexiv robots with `ros2_control`</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/flexiv_robot_states_broadcaster/package.xml
+++ b/flexiv_controllers/flexiv_robot_states_broadcaster/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_robot_states_broadcaster</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>The robot states broadcaster publishes the Flexiv robot states.</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/gpio_controller/package.xml
+++ b/flexiv_controllers/gpio_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gpio_controller</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>Flexiv custom gpio controller to control the GPIOs of the robot.</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_gripper/package.xml
+++ b/flexiv_gripper/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_gripper</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>Package implementing the action server of Flexiv gripper control</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_hardware/package.xml
+++ b/flexiv_hardware/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_hardware</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>Hardware interfaces to Flexiv robots for ROS 2 control</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache 2.0</license>

--- a/flexiv_moveit_config/package.xml
+++ b/flexiv_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_moveit_config</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>MoveIt2 configuration and launch files for Flexiv Rizon robots</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache 2.0</license>

--- a/flexiv_msgs/package.xml
+++ b/flexiv_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_msgs</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>Robot states messages definiton used in RDK</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_test_nodes/package.xml
+++ b/flexiv_test_nodes/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_test_nodes</name>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <description>Demo nodes for testing flexiv_ros2</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## COMPATIBILITY
* Flexiv software package **v3.11.1**
* Flexiv RDK **v1.9.1**
* Flexiv DRDK **v1.2.1** (for dual-robot setup)
* ROS 2 Humble

## ADD
- Add the lite RDK instance option in Flexiv gripper node (#96)

## CHANGE
- Update Humble binary build workflow GitHub Actions.

## FIX
- Update Flexiv bringup launch files' nodes startup order (#97)
