### PR TITLE
Hotfix/Update flexiv_description version to jazzy-v1.9.1

### DIFF
--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -3,10 +3,12 @@ name: Jazzy Binary Build
 on:
   push:
     branches:
-      - jazzy
+      - jazzy-v1
+      - jazzy-v2
   pull_request:
     branches:
-      - jazzy
+      - jazzy-v1
+      - jazzy-v2
       - release/jazzy-*
 
 jobs:

--- a/flexiv.jazzy.repos
+++ b/flexiv.jazzy.repos
@@ -2,7 +2,7 @@ repositories:
   flexiv_description:
     type: git
     url: https://github.com/flexivrobotics/flexiv_description.git
-    version: jazzy-v1
+    version: jazzy-v1.9.1
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git


### PR DESCRIPTION
Updated the `flexiv_description` repository from version `jazzy-v1` to `jazzy-v1.9.1` in the `flexiv.jazzy.repos` file.