### PR TITLE
Release/Flexiv ROS 2 Jazzy 1.9.2

### DIFF
--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and install flexiv_rdk
         shell: bash
         run: |
-          git clone --branch v1.9.1 --depth 1 https://github.com/flexivrobotics/flexiv_rdk.git
+          git clone --branch v1.9.2 --depth 1 https://github.com/flexivrobotics/flexiv_rdk.git
           cd flexiv_rdk/thirdparty
           source /opt/ros/jazzy/setup.bash
           bash build_and_install_dependencies_not_in_ros2.sh ~/flexiv_install 8

--- a/flexiv.jazzy.repos
+++ b/flexiv.jazzy.repos
@@ -6,4 +6,4 @@ repositories:
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git
-    version: v1.9.1
+    version: v1.9.2

--- a/flexiv_bringup/package.xml
+++ b/flexiv_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_bringup</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>Package with launch files and run-time configurations for Flexiv robots with `ros2_control`</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/flexiv_robot_states_broadcaster/include/flexiv_robot_states_broadcaster/flexiv_robot_states.hpp
+++ b/flexiv_controllers/flexiv_robot_states_broadcaster/include/flexiv_robot_states_broadcaster/flexiv_robot_states.hpp
@@ -114,7 +114,6 @@ public:
         message.dq = flexiv_robot_states_ptr->dq;
         message.dtheta = flexiv_robot_states_ptr->dtheta;
         message.tau = flexiv_robot_states_ptr->tau;
-        message.tau_des = flexiv_robot_states_ptr->tau_des;
         message.tau_dot = flexiv_robot_states_ptr->tau_dot;
         message.tau_ext = flexiv_robot_states_ptr->tau_ext;
         message.tau_interact = flexiv_robot_states_ptr->tau_interact;

--- a/flexiv_controllers/flexiv_robot_states_broadcaster/package.xml
+++ b/flexiv_controllers/flexiv_robot_states_broadcaster/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_robot_states_broadcaster</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>The robot states broadcaster publishes the Flexiv robot states.</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/gpio_controller/package.xml
+++ b/flexiv_controllers/gpio_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gpio_controller</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>Flexiv custom gpio controller to control the GPIOs of the robot.</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_gripper/package.xml
+++ b/flexiv_gripper/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_gripper</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>Package implementing the action server of Flexiv gripper control</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_hardware/package.xml
+++ b/flexiv_hardware/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_hardware</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>Hardware interfaces to Flexiv robots for ROS 2 control</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache 2.0</license>

--- a/flexiv_moveit_config/package.xml
+++ b/flexiv_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_moveit_config</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>MoveIt2 configuration and launch files for Flexiv Rizon robots</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache 2.0</license>

--- a/flexiv_msgs/msg/RobotStates.msg
+++ b/flexiv_msgs/msg/RobotStates.msg
@@ -19,9 +19,6 @@ float64[] dtheta
 # Measured joint torques
 float64[] tau
 
-# Desired joint torques
-float64[] tau_des
-
 # Numerical derivative of measured joint torques
 float64[] tau_dot
 

--- a/flexiv_msgs/package.xml
+++ b/flexiv_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_msgs</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>Robot states messages definiton used in RDK</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_test_nodes/flexiv_test_nodes/robot_states_publisher.py
+++ b/flexiv_test_nodes/flexiv_test_nodes/robot_states_publisher.py
@@ -187,7 +187,6 @@ class RobotStatesPublisher(Node):
             msg.dq = list(robot_states.dq)  # Joint velocities (link-side)
             msg.dtheta = list(robot_states.dtheta)  # Joint velocities (motor-side)
             msg.tau = list(robot_states.tau)  # Joint torques
-            msg.tau_des = list(robot_states.tau_des)  # Desired joint torques
             msg.tau_dot = list(robot_states.tau_dot)  # Joint torque derivatives
             msg.tau_ext = list(robot_states.tau_ext)  # External joint torques
             msg.tau_interact = list(

--- a/flexiv_test_nodes/package.xml
+++ b/flexiv_test_nodes/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_test_nodes</name>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <description>Demo nodes for testing flexiv_ros2</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
This pull request updates the Flexiv ROS 2 packages and related resources from version 1.9.1 to 1.9.2. In addition to version bumps across multiple `package.xml` files, it removes the `tau_des` (desired joint torques) field from the robot states message and all related code, reflecting a change in the message definition and its usage throughout the codebase.

Version updates:

* Bumped version from `1.9.1` to `1.9.2` in all relevant `package.xml` files, `flexiv.jazzy.repos`, and updated the GitHub Actions workflow to use the `v1.9.2` branch of `flexiv_rdk`.

Robot states message and code cleanup:

* Removed the `tau_des` (desired joint torques) field from the `flexiv_msgs/msg/RobotStates.msg` definition.
* Removed all code referencing or assigning `tau_des` in the robot states broadcaster C++ header and the Python robot states publisher.