### PR TITLE
Task/Adapt to consolidated flexiv_description (humble-v1.9.3)

### DIFF
--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - humble-v1
-      - humble-v2
+      - humble
   pull_request:
     branches:
       - humble-v1
-      - humble-v2
+      - humble
       - release/humble-*
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The prerequisites of using ROS 2 with Flexiv Rizon robot are [enable RDK on the 
 The main launch file to start the robot driver is the `rizon.launch.py` - it loads and starts the robot hardware, joint states broadcaster, Flexiv robot states broadcasters, and robot controller and opens RViZ. The arguments for the launch file are as follows:
 
 - `robot_sn` (*required*) - Serial number of the robot to connect to. Remove any space, for example: Rizon4s-123456
-- `rizon_type` (default: *Rizon4*) - type of the Flexiv Rizon robot. (Rizon4, Rizon4M, Rizon4R, Rizon4s, Rizon10 or Rizon10s)
+- `robot_type` (default: *Rizon4*) - type of the Flexiv robot. (Rizon4, Rizon4M, Rizon4R, Rizon4s, Rizon10 or Rizon10s)
 - `rdk_control_mode` (default: *joint_position*) - Flexiv RDK control mode for ROS 2 joint position and velocity interfaces. Options: *joint_position* or *joint_impedance*
 - `load_gripper` (default: *false*) - loads the Flexiv Grav gripper as the end-effector of the robot and the gripper control node.
 - `use_fake_hardware` (default: *false*) - starts `FakeSystem` instead of real hardware. This is a simple simulation that mimics joint command to their states.
@@ -162,7 +162,7 @@ There are extra or different launch arguments for Flexiv AICO1, AICO2, and dual 
 
 - `robot_sn_left` (*required for dual robot setup*) - Serial number of the left robot to connect to. Remove any space, for example: Rizon4-123456
 - `robot_sn_right` (*required for dual robot setup*) - Serial number of the right robot to connect to. Remove any space, for example: Rizon4R-654321
-- `external_axis_type` (default: *AICO1-4-V1*) - type of the Flexiv AICO1 robot platform. Options: *AICO1-4-V1* or *AICO1-4-V2*
+- `robot_type` (default: *AICO1-4-V1*) - type of the Flexiv AICO1 robot platform. Options: *AICO1-4-V1* or *AICO1-4-V2*
 
 ### Example Commands
 
@@ -171,7 +171,7 @@ There are extra or different launch arguments for Flexiv AICO1, AICO2, and dual 
    - Test with real robot:
 
      ```bash
-     ros2 launch flexiv_bringup rizon.launch.py robot_sn:=[robot_sn] rizon_type:=Rizon4
+     ros2 launch flexiv_bringup rizon.launch.py robot_sn:=[robot_sn] robot_type:=Rizon4
      ```
 
    - Test with fake hardware (`ros2_control` capability):
@@ -198,13 +198,13 @@ There are extra or different launch arguments for Flexiv AICO1, AICO2, and dual 
 **AICO1-4** robot:
 
 ```bash
-ros2 launch flexiv_bringup aico1.launch.py robot_sn:=[robot_sn] rizon_type:=Rizon4 external_axis_type:=AICO1-4-V1
+ros2 launch flexiv_bringup aico1.launch.py robot_sn:=[robot_sn] robot_type:=AICO1-4-V1
 ```
 
 **AICO2-4** robot:
 
 ```bash
-ros2 launch flexiv_bringup aico2.launch.py rizon_type:=Rizon4 robot_sn_left:=[robot_sn_left] robot_sn_right:=[robot_sn_right] external_axis_type:=AICO2-4-V1
+ros2 launch flexiv_bringup aico2.launch.py robot_sn_left:=[robot_sn_left] robot_sn_right:=[robot_sn_right] robot_type:=AICO2-4-V1
 ```
 
 ### Using MoveIt
@@ -230,13 +230,13 @@ ros2 launch flexiv_bringup rizon_dual_moveit.launch.py robot_sn_left:=[robot_sn_
 With AICO1-4 setup:
 
 ```bash
-ros2 launch flexiv_bringup aico1_moveit.launch.py robot_sn:=[robot_sn] rizon_type:=Rizon4 external_axis_type:=AICO1-4-V1
+ros2 launch flexiv_bringup aico1_moveit.launch.py robot_sn:=[robot_sn] robot_type:=AICO1-4-V1
 ```
 
 With AICO2-4 setup:
 
 ```bash
-ros2 launch flexiv_bringup aico2_moveit.launch.py rizon_type:=Rizon4 robot_sn_left:=[robot_sn_left] robot_sn_right:=[robot_sn_right] external_axis_type:=AICO2-4-V1
+ros2 launch flexiv_bringup aico2_moveit.launch.py robot_sn_left:=[robot_sn_left] robot_sn_right:=[robot_sn_right] robot_type:=AICO2-4-V1
 ```
 
 ### Robot States

--- a/flexiv.humble.repos
+++ b/flexiv.humble.repos
@@ -2,7 +2,7 @@ repositories:
   flexiv_description:
     type: git
     url: https://github.com/flexivrobotics/flexiv_description.git
-    version: humble
+    version: humble-v3.0
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git

--- a/flexiv.humble.repos
+++ b/flexiv.humble.repos
@@ -2,7 +2,7 @@ repositories:
   flexiv_description:
     type: git
     url: https://github.com/flexivrobotics/flexiv_description.git
-    version: humble-v1.9.1
+    version: humble
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git

--- a/flexiv_bringup/launch/aico1.launch.py
+++ b/flexiv_bringup/launch/aico1.launch.py
@@ -22,7 +22,7 @@ from launch.substitutions import (
 
 
 def generate_launch_description():
-    rizon_type_param_name = "rizon_type"
+    arm_type_param_name = "arm_type"
     robot_sn_param_name = "robot_sn"
     rdk_control_mode_param_name = "rdk_control_mode"
     start_rviz_param_name = "start_rviz"
@@ -32,17 +32,16 @@ def generate_launch_description():
     use_fake_hardware_param_name = "use_fake_hardware"
     fake_sensor_commands_param_name = "fake_sensor_commands"
     robot_controller_param_name = "robot_controller"
-    external_axis_type_param_name = "external_axis_type"
+    robot_type_param_name = "robot_type"
     external_axis_prefix_param_name = "external_axis_prefix"
-    arm_prefix_param_name = "arm_prefix"
 
     # Declare arguments
     declared_arguments = []
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            rizon_type_param_name,
-            description="Type of the Flexiv Rizon robot.",
+            arm_type_param_name,
+            description="Type of the arm carried by the external axis.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon4s"],
         )
@@ -123,7 +122,7 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            external_axis_type_param_name,
+            robot_type_param_name,
             default_value="AICO1-4-V1",
             description="Type of the AICO1 platform.",
             choices=["AICO1-4-V1", "AICO1-4-V2"],
@@ -138,16 +137,8 @@ def generate_launch_description():
         )
     )
 
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            arm_prefix_param_name,
-            default_value="",
-            description="Prefix for the arm links and joints.",
-        )
-    )
-
     # Initialize Arguments
-    rizon_type = LaunchConfiguration(rizon_type_param_name)
+    arm_type = LaunchConfiguration(arm_type_param_name)
     robot_sn = LaunchConfiguration(robot_sn_param_name)
     rdk_control_mode = LaunchConfiguration(rdk_control_mode_param_name)
     start_rviz = LaunchConfiguration(start_rviz_param_name)
@@ -157,9 +148,8 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration(use_fake_hardware_param_name)
     fake_sensor_commands = LaunchConfiguration(fake_sensor_commands_param_name)
     robot_controller = LaunchConfiguration(robot_controller_param_name)
-    external_axis_type = LaunchConfiguration(external_axis_type_param_name)
+    robot_type = LaunchConfiguration(robot_type_param_name)
     external_axis_prefix = LaunchConfiguration(external_axis_prefix_param_name)
-    arm_prefix = LaunchConfiguration(arm_prefix_param_name)
     gripper_ready_gate_condition = PythonExpression(
         [
             "'",
@@ -172,7 +162,7 @@ def generate_launch_description():
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "aico1.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     # Get URDF via xacro
@@ -186,8 +176,8 @@ def generate_launch_description():
                 "robot_sn:=",
                 robot_sn,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "arm_type:=",
+                arm_type,
                 " ",
                 "ros2_control:=true ",
                 "rdk_control_mode:=",
@@ -208,16 +198,11 @@ def generate_launch_description():
                 "fake_sensor_commands:=",
                 fake_sensor_commands,
                 " ",
-                "external_axis_type:=",
-                PythonExpression(
-                    ["'", external_axis_type, "'.lower().replace('-', '_')"]
-                ),
+                "robot_type:=",
+                robot_type,
                 " ",
                 "external_axis_prefix:=",
                 external_axis_prefix,
-                " ",
-                "arm_prefix:=",
-                arm_prefix,
             ]
         ),
         value_type=str,
@@ -227,7 +212,7 @@ def generate_launch_description():
 
     # RViZ
     rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "rviz", "view_rizon.rviz"]
+        [FindPackageShare("flexiv_description"), "rviz", "view_flexiv.rviz"]
     )
 
     rviz_node = Node(
@@ -243,7 +228,7 @@ def generate_launch_description():
     controller_file_name = PythonExpression(
         [
             "'aico1_4_v2_controllers.yaml' if '",
-            external_axis_type,
+            robot_type,
             "' == 'AICO1-4-V2' else 'aico1_4_v1_controllers.yaml'",
         ]
     )

--- a/flexiv_bringup/launch/aico1_moveit.launch.py
+++ b/flexiv_bringup/launch/aico1_moveit.launch.py
@@ -46,7 +46,7 @@ def load_yaml(package_name, file_path, replacements=None):
 
 
 def launch_setup(context):
-    rizon_type = LaunchConfiguration("rizon_type")
+    arm_type = LaunchConfiguration("arm_type")
     robot_sn = LaunchConfiguration("robot_sn")
     rdk_control_mode = LaunchConfiguration("rdk_control_mode")
     start_rviz = LaunchConfiguration("start_rviz")
@@ -56,9 +56,8 @@ def launch_setup(context):
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
-    external_axis_type = LaunchConfiguration("external_axis_type")
+    robot_type = LaunchConfiguration("robot_type")
     external_axis_prefix = LaunchConfiguration("external_axis_prefix")
-    arm_prefix = LaunchConfiguration("arm_prefix")
     gripper_ready_gate_condition = PythonExpression(
         [
             "'",
@@ -70,21 +69,15 @@ def launch_setup(context):
     )
 
     robot_sn_str = robot_sn.perform(context)
-    arm_prefix_str = arm_prefix.perform(context)
     external_axis_prefix_str = external_axis_prefix.perform(context)
-    external_axis_type_str = external_axis_type.perform(context)
+    robot_type_str = robot_type.perform(context)
 
     # Construct prefix
-    prefix_str = ""
-
-    if arm_prefix_str and robot_sn_str:
-        prefix_str = arm_prefix_str + "_" + robot_sn_str + "_"
-    elif arm_prefix_str or robot_sn_str:
-        prefix_str = arm_prefix_str + robot_sn_str + "_"
+    prefix_str = robot_sn_str + "_" if robot_sn_str else ""
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "aico1.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     robot_description_content = ParameterValue(
@@ -97,8 +90,8 @@ def launch_setup(context):
                 "robot_sn:=",
                 robot_sn,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "arm_type:=",
+                arm_type,
                 " ",
                 "ros2_control:=true ",
                 "rdk_control_mode:=",
@@ -119,16 +112,11 @@ def launch_setup(context):
                 "fake_sensor_commands:=",
                 fake_sensor_commands,
                 " ",
-                "external_axis_type:=",
-                PythonExpression(
-                    ["'", external_axis_type, "'.lower().replace('-', '_')"]
-                ),
+                "robot_type:=",
+                robot_type,
                 " ",
                 "external_axis_prefix:=",
                 external_axis_prefix,
-                " ",
-                "arm_prefix:=",
-                arm_prefix,
             ]
         ),
         value_type=str,
@@ -157,16 +145,11 @@ def launch_setup(context):
                 "load_mounted_ft_sensor:=",
                 load_mounted_ft_sensor,
                 " ",
-                "external_axis_type:=",
-                PythonExpression(
-                    ["'", external_axis_type, "'.lower().replace('-', '_')"]
-                ),
+                "robot_type:=",
+                robot_type,
                 " ",
                 "external_axis_prefix:=",
                 external_axis_prefix,
-                " ",
-                "arm_prefix:=",
-                arm_prefix,
             ]
         ),
         value_type=str,
@@ -209,7 +192,7 @@ def launch_setup(context):
     ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     controllers_file = "config/aico/aico1_4_v1_moveit_controllers.yaml"
-    if external_axis_type_str == "AICO1-4-V2":
+    if robot_type_str == "AICO1-4-V2":
         controllers_file = "config/aico/aico1_4_v2_moveit_controllers.yaml"
 
     moveit_simple_controllers_yaml = load_yaml(
@@ -320,7 +303,7 @@ def launch_setup(context):
 
     # Robot controllers
     ros2_controllers_file = "aico1_4_v1_controllers.yaml"
-    if external_axis_type_str == "AICO1-4-V2":
+    if robot_type_str == "AICO1-4-V2":
         ros2_controllers_file = "aico1_4_v2_controllers.yaml"
     robot_controllers = PathJoinSubstitution(
         [FindPackageShare("flexiv_bringup"), "config", ros2_controllers_file]
@@ -490,8 +473,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "rizon_type",
-            description="Type of the Flexiv Rizon robot.",
+            "arm_type",
+            description="Type of the arm carried by the external axis.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon4s"],
         )
@@ -572,7 +555,7 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "external_axis_type",
+            "robot_type",
             default_value="AICO1-4-V1",
             description="Type of the AICO1 platform.",
             choices=["AICO1-4-V1", "AICO1-4-V2"],
@@ -584,14 +567,6 @@ def generate_launch_description():
             "external_axis_prefix",
             default_value="",
             description="Prefix for the external axis links and joints.",
-        )
-    )
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "arm_prefix",
-            default_value="",
-            description="Prefix for the arm links and joints.",
         )
     )
 

--- a/flexiv_bringup/launch/aico2.launch.py
+++ b/flexiv_bringup/launch/aico2.launch.py
@@ -22,7 +22,7 @@ from launch.substitutions import (
 
 
 def generate_launch_description():
-    rizon_type_param_name = "rizon_type"
+    arm_type_param_name = "arm_type"
     robot_sn_left_param_name = "robot_sn_left"
     robot_sn_right_param_name = "robot_sn_right"
     rdk_control_mode_param_name = "rdk_control_mode"
@@ -35,7 +35,7 @@ def generate_launch_description():
     gripper_name_right_param_name = "gripper_name_right"
     load_mounted_ft_sensor_left_param_name = "load_mounted_ft_sensor_left"
     load_mounted_ft_sensor_right_param_name = "load_mounted_ft_sensor_right"
-    external_axis_type_param_name = "external_axis_type"
+    robot_type_param_name = "robot_type"
     external_axis_prefix_param_name = "external_axis_prefix"
 
     # Declare arguments
@@ -43,8 +43,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            rizon_type_param_name,
-            description="Type of the Flexiv Rizon robot.",
+            arm_type_param_name,
+            description="Type of the arm carried by the external axis.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon10"],
         )
@@ -147,7 +147,7 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            external_axis_type_param_name,
+            robot_type_param_name,
             default_value="AICO2-4-V1",
             description="Type of the AICO2 platform.",
             choices=["AICO2-4-V1", "AICO2-4-V2", "AICO2-10-V1"],
@@ -163,7 +163,7 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-    rizon_type = LaunchConfiguration(rizon_type_param_name)
+    arm_type = LaunchConfiguration(arm_type_param_name)
     robot_sn_left = LaunchConfiguration(robot_sn_left_param_name)
     robot_sn_right = LaunchConfiguration(robot_sn_right_param_name)
     rdk_control_mode = LaunchConfiguration(rdk_control_mode_param_name)
@@ -180,7 +180,7 @@ def generate_launch_description():
     load_mounted_ft_sensor_right = LaunchConfiguration(
         load_mounted_ft_sensor_right_param_name
     )
-    external_axis_type = LaunchConfiguration(external_axis_type_param_name)
+    robot_type = LaunchConfiguration(robot_type_param_name)
     external_axis_prefix = LaunchConfiguration(external_axis_prefix_param_name)
     left_gripper_ready_gate_condition = PythonExpression(
         [
@@ -206,16 +206,34 @@ def generate_launch_description():
 
     set_prefix_left = SetLaunchConfiguration(
         name="prefix_left",
-        value=PythonExpression(["'left_' + '", robot_sn_left, "' + '_'"]),
+        # Matches compute_arm_prefix in flexiv_description: the separator only
+        # appears when the part it separates is non-empty.
+        value=PythonExpression(
+            [
+                "'left_' + '",
+                robot_sn_left,
+                "' + '_' if '",
+                robot_sn_left,
+                "' else 'left_'",
+            ]
+        ),
     )
     set_prefix_right = SetLaunchConfiguration(
         name="prefix_right",
-        value=PythonExpression(["'right_' + '", robot_sn_right, "' + '_'"]),
+        value=PythonExpression(
+            [
+                "'right_' + '",
+                robot_sn_right,
+                "' + '_' if '",
+                robot_sn_right,
+                "' else 'right_'",
+            ]
+        ),
     )
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "aico2.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     robot_description_content = ParameterValue(
@@ -225,8 +243,13 @@ def generate_launch_description():
                 " ",
                 flexiv_urdf_xacro,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "arm_type_left:=",
+                arm_type,
+                " ",
+                "arm_type_right:=",
+                PythonExpression(
+                    ["'Rizon4R' if '", arm_type, "' == 'Rizon4' else '", arm_type, "'"]
+                ),
                 " ",
                 "robot_sn_left:=",
                 robot_sn_left,
@@ -262,10 +285,8 @@ def generate_launch_description():
                 "fake_sensor_commands:=",
                 fake_sensor_commands,
                 " ",
-                "external_axis_type:=",
-                PythonExpression(
-                    ["'", external_axis_type, "'.lower().replace('-', '_')"]
-                ),
+                "robot_type:=",
+                robot_type,
                 " ",
                 "external_axis_prefix:=",
                 external_axis_prefix,
@@ -278,7 +299,7 @@ def generate_launch_description():
 
     # RViZ
     rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "rviz", "view_rizon.rviz"]
+        [FindPackageShare("flexiv_description"), "rviz", "view_flexiv.rviz"]
     )
 
     rviz_node = Node(
@@ -294,9 +315,9 @@ def generate_launch_description():
     controller_file_name = PythonExpression(
         [
             "'aico2_10_v1_controllers.yaml' if '",
-            external_axis_type,
+            robot_type,
             "' == 'AICO2-10-V1' else ('aico2_4_v2_controllers.yaml' if '",
-            external_axis_type,
+            robot_type,
             "' == 'AICO2-4-V2' else 'aico2_4_v1_controllers.yaml')",
         ]
     )

--- a/flexiv_bringup/launch/aico2_moveit.launch.py
+++ b/flexiv_bringup/launch/aico2_moveit.launch.py
@@ -26,6 +26,17 @@ from launch.substitutions import (
 )
 
 
+def arm_prefix(side, robot_sn):
+    """Build a link/joint name prefix, matching compute_arm_prefix in
+    flexiv_description's flexiv_common.xacro: the separating underscore only
+    appears when the part it separates is non-empty."""
+    if side and robot_sn:
+        return side + "_" + robot_sn + "_"
+    if side or robot_sn:
+        return side + robot_sn + "_"
+    return ""
+
+
 def load_yaml(package_name, file_path, replacements=None):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
@@ -47,7 +58,7 @@ def load_yaml(package_name, file_path, replacements=None):
 
 def launch_setup(context):
     # Initialize Arguments
-    rizon_type = LaunchConfiguration("rizon_type")
+    arm_type = LaunchConfiguration("arm_type")
     robot_sn_left = LaunchConfiguration("robot_sn_left")
     robot_sn_right = LaunchConfiguration("robot_sn_right")
 
@@ -85,18 +96,18 @@ def launch_setup(context):
         ]
     )
 
-    external_axis_type = LaunchConfiguration("external_axis_type")
+    robot_type = LaunchConfiguration("robot_type")
     external_axis_prefix = LaunchConfiguration("external_axis_prefix")
 
     warehouse_sqlite_path = LaunchConfiguration("warehouse_sqlite_path")
 
-    external_axis_type_str = external_axis_type.perform(context)
+    robot_type_str = robot_type.perform(context)
     external_axis_prefix_str = external_axis_prefix.perform(context)
 
     # Construct prefixes
-    prefix_left_str = "left_" + robot_sn_left_str + "_"
+    prefix_left_str = arm_prefix("left", robot_sn_left_str)
 
-    prefix_right_str = "right_" + robot_sn_right_str + "_"
+    prefix_right_str = arm_prefix("right", robot_sn_right_str)
 
     set_prefix_left = SetLaunchConfiguration(name="prefix_left", value=prefix_left_str)
     set_prefix_right = SetLaunchConfiguration(
@@ -105,7 +116,7 @@ def launch_setup(context):
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "aico2.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     robot_description_content = ParameterValue(
@@ -115,8 +126,13 @@ def launch_setup(context):
                 " ",
                 flexiv_urdf_xacro,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "arm_type_left:=",
+                arm_type,
+                " ",
+                "arm_type_right:=",
+                PythonExpression(
+                    ["'Rizon4R' if '", arm_type, "' == 'Rizon4' else '", arm_type, "'"]
+                ),
                 " ",
                 "robot_sn_left:=",
                 robot_sn_left,
@@ -152,10 +168,8 @@ def launch_setup(context):
                 "fake_sensor_commands:=",
                 fake_sensor_commands,
                 " ",
-                "external_axis_type:=",
-                PythonExpression(
-                    ["'", external_axis_type, "'.lower().replace('-', '_')"]
-                ),
+                "robot_type:=",
+                robot_type,
                 " ",
                 "external_axis_prefix:=",
                 external_axis_prefix,
@@ -197,15 +211,13 @@ def launch_setup(context):
                 load_mounted_ft_sensor_right,
                 " ",
                 "arm_prefix_left:=",
-                "left_",
+                "left",
                 " ",
                 "arm_prefix_right:=",
-                "right_",
+                "right",
                 " ",
-                "external_axis_type:=",
-                PythonExpression(
-                    ["'", external_axis_type, "'.lower().replace('-', '_')"]
-                ),
+                "robot_type:=",
+                robot_type,
                 " ",
                 "external_axis_prefix:=",
                 external_axis_prefix,
@@ -252,9 +264,9 @@ def launch_setup(context):
     ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     controllers_file = "config/aico/aico2_4_v1_moveit_controllers.yaml"
-    if external_axis_type_str == "AICO2-10-V1":
+    if robot_type_str == "AICO2-10-V1":
         controllers_file = "config/aico/aico2_10_v1_moveit_controllers.yaml"
-    elif external_axis_type_str == "AICO2-4-V2":
+    elif robot_type_str == "AICO2-4-V2":
         controllers_file = "config/aico/aico2_4_v2_moveit_controllers.yaml"
 
     moveit_simple_controllers_yaml = load_yaml(
@@ -375,9 +387,9 @@ def launch_setup(context):
 
     # Robot controllers
     ros2_controllers_file = "aico2_4_v1_controllers.yaml"
-    if external_axis_type_str == "AICO2-10-V1":
+    if robot_type_str == "AICO2-10-V1":
         ros2_controllers_file = "aico2_10_v1_controllers.yaml"
-    elif external_axis_type_str == "AICO2-4-V2":
+    elif robot_type_str == "AICO2-4-V2":
         ros2_controllers_file = "aico2_4_v2_controllers.yaml"
     robot_controllers = PathJoinSubstitution(
         [FindPackageShare("flexiv_bringup"), "config", ros2_controllers_file]
@@ -660,9 +672,9 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "rizon_type",
+            "arm_type",
             default_value="Rizon4",
-            description="Type of the Flexiv Rizon robot.",
+            description="Type of the arm carried by the external axis.",
             choices=["Rizon4", "Rizon10"],
         )
     )
@@ -764,7 +776,7 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "external_axis_type",
+            "robot_type",
             default_value="AICO2-4-V1",
             description="Type of the AICO2 platform.",
             choices=["AICO2-4-V1", "AICO2-4-V2", "AICO2-10-V1"],

--- a/flexiv_bringup/launch/rizon.launch.py
+++ b/flexiv_bringup/launch/rizon.launch.py
@@ -22,7 +22,7 @@ from launch.substitutions import (
 
 
 def generate_launch_description():
-    rizon_type_param_name = "rizon_type"
+    robot_type_param_name = "robot_type"
     robot_sn_param_name = "robot_sn"
     rdk_control_mode_param_name = "rdk_control_mode"
     start_rviz_param_name = "start_rviz"
@@ -38,8 +38,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            rizon_type_param_name,
-            description="Type of the Flexiv Rizon robot.",
+            robot_type_param_name,
+            description="Type of the Flexiv robot.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )
@@ -119,7 +119,7 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-    rizon_type = LaunchConfiguration(rizon_type_param_name)
+    robot_type = LaunchConfiguration(robot_type_param_name)
     robot_sn = LaunchConfiguration(robot_sn_param_name)
     rdk_control_mode = LaunchConfiguration(rdk_control_mode_param_name)
     start_rviz = LaunchConfiguration(start_rviz_param_name)
@@ -141,7 +141,7 @@ def generate_launch_description():
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "rizon.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     # Get URDF via xacro
@@ -155,8 +155,8 @@ def generate_launch_description():
                 "robot_sn:=",
                 robot_sn,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "robot_type:=",
+                robot_type,
                 " ",
                 "ros2_control:=true ",
                 "rdk_control_mode:=",
@@ -185,7 +185,7 @@ def generate_launch_description():
 
     # RViZ
     rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "rviz", "view_rizon.rviz"]
+        [FindPackageShare("flexiv_description"), "rviz", "view_flexiv.rviz"]
     )
 
     rviz_node = Node(

--- a/flexiv_bringup/launch/rizon_dual.launch.py
+++ b/flexiv_bringup/launch/rizon_dual.launch.py
@@ -22,8 +22,8 @@ from launch.substitutions import (
 
 
 def generate_launch_description():
-    rizon_type_left_param_name = "rizon_type_left"
-    rizon_type_right_param_name = "rizon_type_right"
+    arm_type_left_param_name = "arm_type_left"
+    arm_type_right_param_name = "arm_type_right"
     robot_sn_left_param_name = "robot_sn_left"
     robot_sn_right_param_name = "robot_sn_right"
     rdk_control_mode_param_name = "rdk_control_mode"
@@ -42,8 +42,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            rizon_type_left_param_name,
-            description="Type of the left Flexiv Rizon robot.",
+            arm_type_left_param_name,
+            description="Type of the left arm.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )
@@ -51,8 +51,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            rizon_type_right_param_name,
-            description="Type of the right Flexiv Rizon robot.",
+            arm_type_right_param_name,
+            description="Type of the right arm.",
             default_value="Rizon4R",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )
@@ -154,8 +154,8 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-    rizon_type_left = LaunchConfiguration(rizon_type_left_param_name)
-    rizon_type_right = LaunchConfiguration(rizon_type_right_param_name)
+    arm_type_left = LaunchConfiguration(arm_type_left_param_name)
+    arm_type_right = LaunchConfiguration(arm_type_right_param_name)
     robot_sn_left = LaunchConfiguration(robot_sn_left_param_name)
     robot_sn_right = LaunchConfiguration(robot_sn_right_param_name)
     rdk_control_mode = LaunchConfiguration(rdk_control_mode_param_name)
@@ -196,16 +196,34 @@ def generate_launch_description():
 
     set_prefix_left = SetLaunchConfiguration(
         name="prefix_left",
-        value=PythonExpression(["'left_' + '", robot_sn_left, "' + '_'"]),
+        # Matches compute_arm_prefix in flexiv_description: the separator only
+        # appears when the part it separates is non-empty.
+        value=PythonExpression(
+            [
+                "'left_' + '",
+                robot_sn_left,
+                "' + '_' if '",
+                robot_sn_left,
+                "' else 'left_'",
+            ]
+        ),
     )
     set_prefix_right = SetLaunchConfiguration(
         name="prefix_right",
-        value=PythonExpression(["'right_' + '", robot_sn_right, "' + '_'"]),
+        value=PythonExpression(
+            [
+                "'right_' + '",
+                robot_sn_right,
+                "' + '_' if '",
+                robot_sn_right,
+                "' else 'right_'",
+            ]
+        ),
     )
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "rizon_dual.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     robot_description_content = ParameterValue(
@@ -215,17 +233,18 @@ def generate_launch_description():
                 " ",
                 flexiv_urdf_xacro,
                 " ",
+                "robot_type:=Rizon-Dual ",
                 "robot_sn_left:=",
                 robot_sn_left,
                 " ",
                 "robot_sn_right:=",
                 robot_sn_right,
                 " ",
-                "rizon_type_left:=",
-                rizon_type_left,
+                "arm_type_left:=",
+                arm_type_left,
                 " ",
-                "rizon_type_right:=",
-                rizon_type_right,
+                "arm_type_right:=",
+                arm_type_right,
                 " ",
                 "load_gripper_left:=",
                 load_gripper_left,
@@ -263,7 +282,7 @@ def generate_launch_description():
 
     # RViZ
     rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "rviz", "view_rizon.rviz"]
+        [FindPackageShare("flexiv_description"), "rviz", "view_flexiv.rviz"]
     )
 
     rviz_node = Node(

--- a/flexiv_bringup/launch/rizon_dual_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_dual_moveit.launch.py
@@ -23,7 +23,19 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
+
+
+def arm_prefix(side, robot_sn):
+    """Build a link/joint name prefix, matching compute_arm_prefix in
+    flexiv_description's flexiv_common.xacro: the separating underscore only
+    appears when the part it separates is non-empty."""
+    if side and robot_sn:
+        return side + "_" + robot_sn + "_"
+    if side or robot_sn:
+        return side + robot_sn + "_"
+    return ""
 
 
 def load_yaml(package_name, file_path, replacements=None):
@@ -47,8 +59,8 @@ def load_yaml(package_name, file_path, replacements=None):
 
 def launch_setup(context):
     # Initialize Arguments
-    rizon_type_left = LaunchConfiguration("rizon_type_left")
-    rizon_type_right = LaunchConfiguration("rizon_type_right")
+    arm_type_left = LaunchConfiguration("arm_type_left")
+    arm_type_right = LaunchConfiguration("arm_type_right")
     robot_sn_left = LaunchConfiguration("robot_sn_left")
     robot_sn_right = LaunchConfiguration("robot_sn_right")
 
@@ -89,8 +101,8 @@ def launch_setup(context):
     warehouse_sqlite_path = LaunchConfiguration("warehouse_sqlite_path")
 
     # Construct prefixes
-    prefix_left_str = "left_" + robot_sn_left_str + "_"
-    prefix_right_str = "right_" + robot_sn_right_str + "_"
+    prefix_left_str = arm_prefix("left", robot_sn_left_str)
+    prefix_right_str = arm_prefix("right", robot_sn_right_str)
 
     set_prefix_left = SetLaunchConfiguration(name="prefix_left", value=prefix_left_str)
     set_prefix_right = SetLaunchConfiguration(
@@ -99,7 +111,7 @@ def launch_setup(context):
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "rizon_dual.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     robot_description_content = ParameterValue(
@@ -109,17 +121,18 @@ def launch_setup(context):
                 " ",
                 flexiv_urdf_xacro,
                 " ",
+                "robot_type:=Rizon-Dual ",
                 "robot_sn_left:=",
                 robot_sn_left,
                 " ",
                 "robot_sn_right:=",
                 robot_sn_right,
                 " ",
-                "rizon_type_left:=",
-                rizon_type_left,
+                "arm_type_left:=",
+                arm_type_left,
                 " ",
-                "rizon_type_right:=",
-                rizon_type_right,
+                "arm_type_right:=",
+                arm_type_right,
                 " ",
                 "load_gripper_left:=",
                 load_gripper_left,
@@ -186,10 +199,10 @@ def launch_setup(context):
                 load_mounted_ft_sensor_right,
                 " ",
                 "prefix_left:=",
-                "left_",
+                "left",
                 " ",
                 "prefix_right:=",
-                "right_",
+                "right",
             ]
         ),
         value_type=str,
@@ -617,8 +630,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "rizon_type_left",
-            description="Type of the left Flexiv Rizon robot.",
+            "arm_type_left",
+            description="Type of the left arm.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )
@@ -626,8 +639,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "rizon_type_right",
-            description="Type of the right Flexiv Rizon robot.",
+            "arm_type_right",
+            description="Type of the right arm.",
             default_value="Rizon4R",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )

--- a/flexiv_bringup/launch/rizon_moveit.launch.py
+++ b/flexiv_bringup/launch/rizon_moveit.launch.py
@@ -47,7 +47,7 @@ def load_yaml(package_name, file_path, replacements=None):
 
 def launch_setup(context):
     # Initialize Arguments
-    rizon_type = LaunchConfiguration("rizon_type")
+    robot_type = LaunchConfiguration("robot_type")
     robot_sn = LaunchConfiguration("robot_sn")
     robot_sn_str = robot_sn.perform(context)
     rdk_control_mode = LaunchConfiguration("rdk_control_mode")
@@ -71,7 +71,7 @@ def launch_setup(context):
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "rizon.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     # Get URDF via xacro
@@ -85,8 +85,8 @@ def launch_setup(context):
                 "robot_sn:=",
                 robot_sn,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "robot_type:=",
+                robot_type,
                 " ",
                 "ros2_control:=true ",
                 "rdk_control_mode:=",
@@ -127,8 +127,8 @@ def launch_setup(context):
                 "robot_sn:=",
                 robot_sn,
                 " ",
-                "rizon_type:=",
-                rizon_type,
+                "robot_type:=",
+                robot_type,
                 " ",
                 "load_gripper:=",
                 load_gripper,
@@ -456,8 +456,8 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "rizon_type",
-            description="Type of the Flexiv Rizon robot.",
+            "robot_type",
+            description="Type of the Flexiv robot.",
             default_value="Rizon4",
             choices=["Rizon4", "Rizon4M", "Rizon4R", "Rizon4s", "Rizon10", "Rizon10s"],
         )

--- a/flexiv_hardware/CMakeLists.txt
+++ b/flexiv_hardware/CMakeLists.txt
@@ -71,6 +71,11 @@ install(
   DESTINATION include
 )
 
+install(
+  DIRECTORY ros2_control urdf
+  DESTINATION share/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 endif()

--- a/flexiv_hardware/package.xml
+++ b/flexiv_hardware/package.xml
@@ -15,6 +15,9 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
 
+  <exec_depend>flexiv_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/flexiv_hardware/ros2_control/flexiv.ros2_control.xacro
+++ b/flexiv_hardware/ros2_control/flexiv.ros2_control.xacro
@@ -1,0 +1,157 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- Single-robot ros2_control: one robot_sn, one FlexivHardwareInterface.
+       For two robots paired on a platform (Rizon dual, AICO2) see
+       rizon_dual.ros2_control.xacro instead. -->
+  <xacro:macro name="flexiv_ros2_control"
+    params="
+    prefix
+    robot_sn
+    rdk_control_mode:='joint_position'
+    use_fake_hardware:=false
+    fake_sensor_commands:=false
+    initial_positions_file
+    num_gpio_ports:=20
+    external_axis_type:=''
+    external_axis_prefix:=''
+    ">
+
+    <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
+
+    <xacro:include filename="$(find flexiv_description)/urdf/common/flexiv_common.xacro" />
+    <!-- GPIO is named from robot_sn alone, matching the hardware interface. -->
+    <xacro:compute_arm_prefix robot_sn="${robot_sn}" />
+    <xacro:property name="sn_prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+
+    <ros2_control name="FlexivHardwareInterface" type="system">
+      <hardware>
+        <xacro:if value="${use_fake_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">${fake_sensor_commands}</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:unless value="${use_fake_hardware}">
+          <plugin>flexiv_hardware/FlexivHardwareInterface</plugin>
+          <param name="robot_sn">${robot_sn}</param>
+          <param name="prefix">${prefix}</param>
+          <param name="rdk_control_mode">${rdk_control_mode}</param>
+          <xacro:unless value="${external_axis_type == ''}">
+            <param name="external_axis_type">${external_axis_type}</param>
+          </xacro:unless>
+        </xacro:unless>
+      </hardware>
+
+      <joint name="${prefix}joint1">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint1']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint2">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint2']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint3">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint3']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint4">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint4']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint5">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint5']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint6">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint6']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint7">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint7']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+
+      <!-- External axis joints. AICO1 mounts a single arm on a positioner, so
+           the axis joints join this robot's interface rather than a paired one. -->
+      <xacro:macro name="ext_axis_joint" params="name">
+        <joint name="${external_axis_prefix}${name}">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+      </xacro:macro>
+
+      <xacro:if value="${external_axis_type == 'aico1_4_v1'}">
+        <!-- joint1 is not actuated on this variant. -->
+        <xacro:ext_axis_joint name="aico1_4_v1_joint2" />
+      </xacro:if>
+      <xacro:if value="${external_axis_type == 'aico1_4_v2'}">
+        <xacro:ext_axis_joint name="aico1_4_v2_joint1" />
+        <xacro:ext_axis_joint name="aico1_4_v2_joint2" />
+        <xacro:ext_axis_joint name="aico1_4_v2_joint_head" />
+      </xacro:if>
+
+      <!-- Digital IO ports: 16 on the control box plus 2 in each wrist connector.
+           Enlight-L and MICO have two wrist connectors (20); Rizon has one (18). -->
+      <xacro:macro name="loop_gpio" params="idx">
+        <command_interface name="digital_output_${idx}" />
+        <state_interface name="digital_input_${idx}" />
+        <xacro:if value="${idx &lt; num_gpio_ports - 1}">
+          <xacro:loop_gpio idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <gpio name="${sn_prefix}gpio">
+        <xacro:loop_gpio idx="0" />
+      </gpio>
+
+    </ros2_control>
+  </xacro:macro>
+</robot>

--- a/flexiv_hardware/ros2_control/rizon_dual.ros2_control.xacro
+++ b/flexiv_hardware/ros2_control/rizon_dual.ros2_control.xacro
@@ -1,0 +1,168 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="rizon_dual_ros2_control"
+    params="
+    prefix_left
+    prefix_right
+    robot_sn_left
+    robot_sn_right
+    rdk_control_mode:='joint_position'
+    use_fake_hardware:=false
+    fake_sensor_commands:=false
+    initial_positions_file_left
+    initial_positions_file_right
+    translation_left_x:=0.0
+    translation_left_y:=0.0
+    translation_left_z:=0.0
+    translation_right_x:=0.0
+    translation_right_y:=0.0
+    translation_right_z:=0.0
+    external_axis_type:=''
+    external_axis_prefix:=''
+    ">
+
+    <xacro:property name="initial_positions_left" value="${xacro.load_yaml(initial_positions_file_left)['initial_positions']}"/>
+    <xacro:property name="initial_positions_right" value="${xacro.load_yaml(initial_positions_file_right)['initial_positions']}"/>
+
+    <ros2_control name="FlexivDualHardwareInterface" type="system">
+      <hardware>
+        <xacro:if value="${use_fake_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">${fake_sensor_commands}</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:unless value="${use_fake_hardware}">
+          <plugin>flexiv_hardware/FlexivDualHardwareInterface</plugin>
+          <param name="robot_sn_left">${robot_sn_left}</param>
+          <param name="robot_sn_right">${robot_sn_right}</param>
+          <param name="prefix_left">${prefix_left}</param>
+          <param name="prefix_right">${prefix_right}</param>
+          <param name="rdk_control_mode">${rdk_control_mode}</param>
+          <param name="external_axis_type">${external_axis_type}</param>
+          <param name="translation_left_x">${translation_left_x}</param>
+          <param name="translation_left_y">${translation_left_y}</param>
+          <param name="translation_left_z">${translation_left_z}</param>
+          <param name="translation_right_x">${translation_right_x}</param>
+          <param name="translation_right_y">${translation_right_y}</param>
+          <param name="translation_right_z">${translation_right_z}</param>
+        </xacro:unless>
+      </hardware>
+
+      <xacro:macro name="configure_joint" params="joint_name initial_pos">
+        <joint name="${joint_name}">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">${initial_pos}</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+      </xacro:macro>
+
+      <xacro:configure_joint joint_name="${prefix_left}joint1" initial_pos="${initial_positions_left['joint1']}" />
+      <xacro:configure_joint joint_name="${prefix_left}joint2" initial_pos="${initial_positions_left['joint2']}" />
+      <xacro:configure_joint joint_name="${prefix_left}joint3" initial_pos="${initial_positions_left['joint3']}" />
+      <xacro:configure_joint joint_name="${prefix_left}joint4" initial_pos="${initial_positions_left['joint4']}" />
+      <xacro:configure_joint joint_name="${prefix_left}joint5" initial_pos="${initial_positions_left['joint5']}" />
+      <xacro:configure_joint joint_name="${prefix_left}joint6" initial_pos="${initial_positions_left['joint6']}" />
+      <xacro:configure_joint joint_name="${prefix_left}joint7" initial_pos="${initial_positions_left['joint7']}" />
+
+      <!-- External axis joints -->
+      <xacro:if value="${external_axis_type == 'aico2_4_v1'}">
+        <joint name="${external_axis_prefix}aico2_4_v1_joint1">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+        <joint name="${external_axis_prefix}aico2_4_v1_joint2">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+      </xacro:if>
+      <xacro:if value="${external_axis_type == 'aico2_4_v2'}">
+        <joint name="${external_axis_prefix}aico2_4_v2_joint1">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+        <joint name="${external_axis_prefix}aico2_4_v2_joint2">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+      </xacro:if>
+      <xacro:if value="${external_axis_type == 'aico2_10_v1'}">
+        <joint name="${external_axis_prefix}aico2_10_v1_joint1">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+        <joint name="${external_axis_prefix}aico2_10_v1_joint2">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+      </xacro:if>
+
+      <xacro:configure_joint joint_name="${prefix_right}joint1" initial_pos="${initial_positions_right['joint1']}" />
+      <xacro:configure_joint joint_name="${prefix_right}joint2" initial_pos="${initial_positions_right['joint2']}" />
+      <xacro:configure_joint joint_name="${prefix_right}joint3" initial_pos="${initial_positions_right['joint3']}" />
+      <xacro:configure_joint joint_name="${prefix_right}joint4" initial_pos="${initial_positions_right['joint4']}" />
+      <xacro:configure_joint joint_name="${prefix_right}joint5" initial_pos="${initial_positions_right['joint5']}" />
+      <xacro:configure_joint joint_name="${prefix_right}joint6" initial_pos="${initial_positions_right['joint6']}" />
+      <xacro:configure_joint joint_name="${prefix_right}joint7" initial_pos="${initial_positions_right['joint7']}" />
+
+      <!-- 18 digital IO ports per robot -->
+      <xacro:macro name="loop_gpio" params="idx">
+        <command_interface name="digital_output_${idx}" />
+        <state_interface name="digital_input_${idx}" />
+        <xacro:if value="${idx &lt; 17}">
+          <xacro:loop_gpio idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <gpio name="${prefix_left}gpio">
+        <xacro:loop_gpio idx="0" />
+      </gpio>
+
+      <gpio name="${prefix_right}gpio">
+        <xacro:loop_gpio idx="0" />
+      </gpio>
+
+    </ros2_control>
+  </xacro:macro>
+</robot>

--- a/flexiv_hardware/urdf/flexiv.urdf.xacro
+++ b/flexiv_hardware/urdf/flexiv.urdf.xacro
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  flexiv_description model + the ros2_control block for flexiv_hardware.
+  Use flexiv_description's entry point for visualization, this one for control.
+
+  This release supports the Rizon and AICO models only. flexiv_description hosts
+  every Flexiv model, so asking for an unsupported one is rejected below.
+
+  robot_type must be passed on the command line: it names the robot element,
+  which xacro resolves before <xacro:arg> defaults are read.
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="$(arg robot_type)">
+
+  <xacro:arg name="robot_type" default="Rizon4" />
+
+  <!-- Other args come from the description entry point included below. -->
+  <xacro:arg name="ros2_control" default="true" />
+  <xacro:arg name="rdk_control_mode" default="joint_position" />
+  <xacro:arg name="use_fake_hardware" default="false" />
+  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="initial_positions_file" default="" />
+
+  <!-- Robot model, including the arg declarations this file relies on
+       (robot_sn, robot_sn_left/right, arm_type*, arm_prefix, external_axis_prefix). -->
+  <xacro:include filename="$(find flexiv_description)/urdf/flexiv.urdf.xacro" />
+
+  <xacro:if value="$(arg ros2_control)">
+    <xacro:include filename="$(find flexiv_description)/urdf/common/flexiv_common.xacro" />
+    <xacro:include filename="$(find flexiv_hardware)/ros2_control/flexiv.ros2_control.xacro" />
+    <xacro:include filename="$(find flexiv_hardware)/ros2_control/rizon_dual.ros2_control.xacro" />
+
+    <xacro:property name="cfg" value="$(find flexiv_description)/config" />
+    <xacro:property name="rtype" value="$(arg robot_type)" />
+
+    <xacro:property name="single_arms"
+      value="${['Rizon4', 'Rizon4s', 'Rizon4M', 'Rizon4R', 'Rizon10', 'Rizon10s']}" />
+    <xacro:property name="is_single" value="${rtype in single_arms}" />
+    <xacro:property name="is_aico1" value="${rtype in ['AICO1-4-V1', 'AICO1-4-V2']}" />
+    <xacro:property name="is_aico2"
+      value="${rtype in ['AICO2-4-V1', 'AICO2-4-V2', 'AICO2-10-V1']}" />
+    <xacro:property name="is_rizon_dual" value="${rtype == 'Rizon-Dual'}" />
+    <!-- Two robots with two serial numbers, as opposed to one robot with two arms. -->
+    <xacro:property name="is_paired" value="${is_rizon_dual or is_aico2}" />
+
+    <xacro:unless value="${is_single or is_aico1 or is_paired}">
+      ${xacro.error('robot_type ' + rtype + ' is not supported by this release. Supported: '
+        + ', '.join(single_arms + ['AICO1-4-V1', 'AICO1-4-V2', 'Rizon-Dual', 'AICO2-4-V1', 'AICO2-4-V2', 'AICO2-10-V1']))}
+    </xacro:unless>
+
+    <!-- The hardware interface takes the external axis as a lowercase name. -->
+    <xacro:property name="external_axis_type"
+      value="${rtype.lower().replace('-', '_') if (is_aico1 or is_aico2) else ''}" />
+
+    <!-- Arms carried by an external axis or paired platform. Empty means 'use the
+         arm this model actually carries', matching the description's defaults. -->
+    <xacro:property name="aico1_arm"
+      value="${'$(arg arm_type)' if '$(arg arm_type)' != '' else 'Rizon4'}" />
+    <xacro:property name="paired_default_left" value="${'Rizon10' if rtype == 'AICO2-10-V1' else 'Rizon4'}" />
+    <xacro:property name="paired_default_right" value="${'Rizon10' if rtype == 'AICO2-10-V1' else 'Rizon4R'}" />
+    <xacro:property name="arm_left"
+      value="${'$(arg arm_type_left)' if '$(arg arm_type_left)' != '' else paired_default_left}" />
+    <xacro:property name="arm_right"
+      value="${'$(arg arm_type_right)' if '$(arg arm_type_right)' != '' else paired_default_right}" />
+
+    <!-- Rizon has 18 digital IO ports: 16 on the control box plus 2 in its wrist connector. -->
+    <xacro:property name="num_gpio_ports" value="18" />
+
+    <!-- ===================== SINGLE ARM ON A MOUNT ===================== -->
+    <xacro:if value="${is_single}">
+      <xacro:compute_arm_prefix arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)" />
+      <xacro:property name="prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+      <xacro:property name="init_file"
+        value="${'$(arg initial_positions_file)' if '$(arg initial_positions_file)' != '' else cfg + '/' + rtype + '/initial_positions.yaml'}" />
+
+      <xacro:flexiv_ros2_control
+        prefix="${prefix}"
+        robot_sn="$(arg robot_sn)"
+        rdk_control_mode="$(arg rdk_control_mode)"
+        use_fake_hardware="$(arg use_fake_hardware)"
+        fake_sensor_commands="$(arg fake_sensor_commands)"
+        initial_positions_file="${init_file}"
+        num_gpio_ports="${num_gpio_ports}" />
+    </xacro:if>
+
+    <!-- ============ SINGLE ARM ON AN EXTERNAL AXIS (AICO1) ============ -->
+    <xacro:if value="${is_aico1}">
+      <xacro:compute_arm_prefix arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)" />
+      <xacro:property name="prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+
+      <xacro:flexiv_ros2_control
+        prefix="${prefix}"
+        robot_sn="$(arg robot_sn)"
+        rdk_control_mode="$(arg rdk_control_mode)"
+        use_fake_hardware="$(arg use_fake_hardware)"
+        fake_sensor_commands="$(arg fake_sensor_commands)"
+        initial_positions_file="${cfg}/${aico1_arm}/initial_positions.yaml"
+        num_gpio_ports="${num_gpio_ports}"
+        external_axis_type="${external_axis_type}"
+        external_axis_prefix="$(arg external_axis_prefix)" />
+    </xacro:if>
+
+    <!-- ============ TWO PAIRED ROBOTS (Rizon-Dual, AICO2) ============ -->
+    <xacro:if value="${is_paired}">
+      <xacro:compute_arm_prefix arm_prefix="left" robot_sn="$(arg robot_sn_left)" />
+      <xacro:property name="pair_left" value="${computed_arm_prefix}" lazy_eval="false" />
+      <xacro:compute_arm_prefix arm_prefix="right" robot_sn="$(arg robot_sn_right)" />
+      <xacro:property name="pair_right" value="${computed_arm_prefix}" lazy_eval="false" />
+
+      <xacro:rizon_dual_ros2_control
+        prefix_left="${pair_left}"
+        prefix_right="${pair_right}"
+        robot_sn_left="$(arg robot_sn_left)"
+        robot_sn_right="$(arg robot_sn_right)"
+        rdk_control_mode="$(arg rdk_control_mode)"
+        use_fake_hardware="$(arg use_fake_hardware)"
+        fake_sensor_commands="$(arg fake_sensor_commands)"
+        initial_positions_file_left="${cfg}/${arm_left}/initial_positions.yaml"
+        initial_positions_file_right="${cfg}/${arm_right}/initial_positions.yaml"
+        external_axis_type="${external_axis_type}"
+        external_axis_prefix="$(arg external_axis_prefix)" />
+    </xacro:if>
+  </xacro:if>
+
+</robot>

--- a/flexiv_moveit_config/srdf/aico1.srdf.xacro
+++ b/flexiv_moveit_config/srdf/aico1.srdf.xacro
@@ -1,32 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="aico1">
     <!-- parameters -->
-    <xacro:arg name="external_axis_type" default="aico1_4_v1" />
+    <xacro:arg name="robot_type" default="AICO1-4-V1" />
+    <!-- Axis macro/link names are the robot type lowercased with dashes as
+         underscores, e.g. AICO2-10-V1 -> aico2_10_v1. -->
+    <xacro:property name="axis_name"
+      value="${'$(arg robot_type)'.lower().replace('-', '_')}" />
     <xacro:arg name="external_axis_prefix" default="" />
-    <xacro:arg name="arm_prefix" default="" />
     <xacro:arg name="robot_sn" default="" />
     <xacro:arg name="load_gripper" default="false" />
     <xacro:arg name="load_mounted_ft_sensor" default="false" />
 
     <xacro:include filename="$(find flexiv_moveit_config)/srdf/rizon_macro.srdf.xacro" />
 
-    <!-- Arm -->
-    <xacro:rizon_srdf arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)"
-        load_mounted_ft_sensor="$(arg load_mounted_ft_sensor)" use_virtual_joint="false" />
-
     <!-- Prefixes -->
-    <xacro:property name="prefix" value="$(arg arm_prefix)$(arg robot_sn)_" />
+    <xacro:compute_prefix robot_sn="$(arg robot_sn)" />
+    <xacro:property name="prefix" value="${computed_prefix}" lazy_eval="false" />
+
+    <!-- Arm -->
+    <xacro:rizon_srdf prefix="${prefix}"
+        load_mounted_ft_sensor="$(arg load_mounted_ft_sensor)" use_virtual_joint="false" />
     <xacro:property name="external_axis_prefix" value="$(arg external_axis_prefix)" />
 
     <!-- Virtual Joint and Platform Group -->
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico1_4_v1'}">
+    <xacro:if value="${axis_name == 'aico1_4_v1'}">
         <virtual_joint name="virtual_joint" type="fixed" parent_frame="world"
             child_link="${external_axis_prefix}aico1_4_v1_base_link" />
         <group name="${external_axis_prefix}aico1_4_v1_platform_${prefix}arm">
             <chain base_link="${external_axis_prefix}aico1_4_v1_base_link" tip_link="${prefix}flange" />
         </group>
     </xacro:if>
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico1_4_v2'}">
+    <xacro:if value="${axis_name == 'aico1_4_v2'}">
         <virtual_joint name="virtual_joint" type="fixed" parent_frame="world"
             child_link="${external_axis_prefix}aico1_4_v2_base_link" />
         <group name="${external_axis_prefix}aico1_4_v2_platform_${prefix}arm">
@@ -35,7 +39,7 @@
     </xacro:if>
 
     <!-- Platform Collisions -->
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico1_4_v1'}">
+    <xacro:if value="${axis_name == 'aico1_4_v1'}">
         <disable_collisions link1="${prefix}base_link" link2="${external_axis_prefix}aico1_4_v1_link2" reason="Adjacent" />
         <disable_collisions link1="${prefix}base_link" link2="${external_axis_prefix}aico1_4_v1_link1" reason="Never" />
         <disable_collisions link1="${prefix}base_link" link2="${external_axis_prefix}aico1_4_v1_base_link" reason="Never" />
@@ -47,7 +51,7 @@
         <disable_collisions link1="${external_axis_prefix}aico1_4_v1_link1" link2="${external_axis_prefix}aico1_4_v1_link2" reason="Adjacent" />
     </xacro:if>
 
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico1_4_v2'}">
+    <xacro:if value="${axis_name == 'aico1_4_v2'}">
         <disable_collisions link1="${prefix}base_link" link2="${external_axis_prefix}aico1_4_v2_link1" reason="Adjacent" />
         <disable_collisions link1="${prefix}base_link" link2="${external_axis_prefix}aico1_4_v2_base_link" reason="Never" />
         <disable_collisions link1="${prefix}base_link" link2="${external_axis_prefix}aico1_4_v2_neck_link" reason="Never" />
@@ -67,7 +71,7 @@
     <!-- Load gripper -->
     <xacro:if value="$(arg load_gripper)">
         <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
-        <xacro:grav_srdf arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)"
+        <xacro:grav_srdf prefix="${prefix}"
             load_mounted_ft_sensor="$(arg load_mounted_ft_sensor)" />
     </xacro:if>
 

--- a/flexiv_moveit_config/srdf/aico2.srdf.xacro
+++ b/flexiv_moveit_config/srdf/aico2.srdf.xacro
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="aico2">
     <!-- parameters -->
-    <xacro:arg name="external_axis_type" default="aico2_4_v1" />
+    <xacro:arg name="robot_type" default="AICO2-4-V1" />
+    <!-- Axis macro/link names are the robot type lowercased with dashes as
+         underscores, e.g. AICO2-10-V1 -> aico2_10_v1. -->
+    <xacro:property name="axis_name"
+      value="${'$(arg robot_type)'.lower().replace('-', '_')}" />
     <xacro:arg name="external_axis_prefix" default="" />
     <xacro:arg name="robot_sn_left" default="" />
     <xacro:arg name="robot_sn_right" default="" />
@@ -9,40 +13,42 @@
     <xacro:arg name="load_gripper_right" default="false" />
     <xacro:arg name="load_mounted_ft_sensor_left" default="false" />
     <xacro:arg name="load_mounted_ft_sensor_right" default="false" />
-    <xacro:arg name="arm_prefix_left" default="left_" />
-    <xacro:arg name="arm_prefix_right" default="right_" />
+    <xacro:arg name="arm_prefix_left" default="left" />
+    <xacro:arg name="arm_prefix_right" default="right" />
 
     <xacro:include filename="$(find flexiv_moveit_config)/srdf/rizon_macro.srdf.xacro" />
 
+    <!-- Prefixes. lazy_eval is off so each capture resolves before the next call. -->
+    <xacro:compute_prefix side="$(arg arm_prefix_left)" robot_sn="$(arg robot_sn_left)" />
+    <xacro:property name="prefix_left" value="${computed_prefix}" lazy_eval="false" />
+    <xacro:compute_prefix side="$(arg arm_prefix_right)" robot_sn="$(arg robot_sn_right)" />
+    <xacro:property name="prefix_right" value="${computed_prefix}" lazy_eval="false" />
+    <xacro:property name="external_axis_prefix" value="$(arg external_axis_prefix)" />
+
     <!-- Left Arm -->
-    <xacro:rizon_srdf arm_prefix="$(arg arm_prefix_left)" robot_sn="$(arg robot_sn_left)"
+    <xacro:rizon_srdf prefix="${prefix_left}"
         load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_left)" use_virtual_joint="false" />
 
     <!-- Right Arm -->
-    <xacro:rizon_srdf arm_prefix="$(arg arm_prefix_right)" robot_sn="$(arg robot_sn_right)"
+    <xacro:rizon_srdf prefix="${prefix_right}"
         load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_right)" use_virtual_joint="false" />
 
-    <!-- Prefixes -->
-    <xacro:property name="prefix_left" value="$(arg arm_prefix_left)$(arg robot_sn_left)_" />
-    <xacro:property name="prefix_right" value="$(arg arm_prefix_right)$(arg robot_sn_right)_" />
-    <xacro:property name="external_axis_prefix" value="$(arg external_axis_prefix)" />
-
     <!-- Virtual Joint and External Axis Group -->
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico2_4_v1'}">
+    <xacro:if value="${axis_name == 'aico2_4_v1'}">
         <virtual_joint name="virtual_joint" type="fixed" parent_frame="world"
             child_link="${external_axis_prefix}aico2_4_v1_base_link" />
         <group name="${external_axis_prefix}aico2_4_v1_platform_${prefix_left}arm">
             <chain base_link="${external_axis_prefix}aico2_4_v1_base_link" tip_link="${prefix_left}flange" />
         </group>
     </xacro:if>
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico2_4_v2'}">
+    <xacro:if value="${axis_name == 'aico2_4_v2'}">
         <virtual_joint name="virtual_joint" type="fixed" parent_frame="world"
             child_link="${external_axis_prefix}aico2_4_v2_base_link" />
         <group name="${external_axis_prefix}aico2_4_v2_platform_${prefix_left}arm">
             <chain base_link="${external_axis_prefix}aico2_4_v2_base_link" tip_link="${prefix_left}flange" />
         </group>
     </xacro:if>
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico2_10_v1'}">
+    <xacro:if value="${axis_name == 'aico2_10_v1'}">
         <virtual_joint name="virtual_joint" type="fixed" parent_frame="world"
             child_link="${external_axis_prefix}aico2_10_v1_base_link" />
         <group name="${external_axis_prefix}aico2_10_v1_platform_${prefix_left}arm">
@@ -51,7 +57,7 @@
     </xacro:if>
 
     <!-- External Axis Collisions -->
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico2_4_v1'}">
+    <xacro:if value="${axis_name == 'aico2_4_v1'}">
         <!-- Left Arm -->
         <disable_collisions link1="${prefix_left}base_link" link2="${external_axis_prefix}aico2_4_v1_link2" reason="Adjacent" />
         <disable_collisions link1="${prefix_left}base_link" link2="${external_axis_prefix}aico2_4_v1_link1" reason="Never" />
@@ -78,7 +84,7 @@
         <disable_collisions link1="${external_axis_prefix}aico2_4_v1_link1" link2="${external_axis_prefix}aico2_4_v1_link2" reason="Adjacent" />
     </xacro:if>
 
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico2_4_v2'}">
+    <xacro:if value="${axis_name == 'aico2_4_v2'}">
         <!-- Left Arm -->
         <disable_collisions link1="${prefix_left}base_link" link2="${external_axis_prefix}aico2_4_v2_link2" reason="Adjacent" />
         <disable_collisions link1="${prefix_left}base_link" link2="${external_axis_prefix}aico2_4_v2_link1" reason="Never" />
@@ -105,7 +111,7 @@
         <disable_collisions link1="${external_axis_prefix}aico2_4_v2_link1" link2="${external_axis_prefix}aico2_4_v2_link2" reason="Adjacent" />
     </xacro:if>
 
-    <xacro:if value="${'$(arg external_axis_type)' == 'aico2_10_v1'}">
+    <xacro:if value="${axis_name == 'aico2_10_v1'}">
         <!-- Left Arm -->
         <disable_collisions link1="${prefix_left}base_link" link2="${external_axis_prefix}aico2_10_v1_link2" reason="Adjacent" />
         <disable_collisions link1="${prefix_left}base_link" link2="${external_axis_prefix}aico2_10_v1_link1" reason="Never" />
@@ -135,13 +141,13 @@
     <!-- Load grippers -->
     <xacro:if value="$(arg load_gripper_left)">
         <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
-        <xacro:grav_srdf arm_prefix="$(arg prefix_left)" robot_sn="$(arg robot_sn_left)"
+        <xacro:grav_srdf prefix="${prefix_left}"
             load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_left)" />
     </xacro:if>
 
     <xacro:if value="$(arg load_gripper_right)">
         <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
-        <xacro:grav_srdf arm_prefix="$(arg prefix_right)" robot_sn="$(arg robot_sn_right)"
+        <xacro:grav_srdf prefix="${prefix_right}"
             load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_right)" />
     </xacro:if>
 

--- a/flexiv_moveit_config/srdf/grav.srdf.xacro
+++ b/flexiv_moveit_config/srdf/grav.srdf.xacro
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="grav_srdf" params="arm_prefix robot_sn load_mounted_ft_sensor">
-        <!-- Prefix defaults to 'arm_prefix_robot_sn' -->
-        <xacro:property name="prefix" value="${arm_prefix + robot_sn + '_'}" />
+    <!-- 'prefix' is the fully-formed prefix, see compute_prefix in rizon_macro.srdf.xacro. -->
+    <xacro:macro name="grav_srdf" params="prefix load_mounted_ft_sensor">
 
         <group name="${prefix}grav_gripper">
             <joint name="${prefix}gripper_base_joint" />

--- a/flexiv_moveit_config/srdf/rizon.srdf.xacro
+++ b/flexiv_moveit_config/srdf/rizon.srdf.xacro
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg rizon_type)">
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg robot_type)">
     <!-- parameters -->
-    <xacro:arg name="rizon_type" default="Rizon4" />
-    <xacro:arg name="arm_prefix" default="" />
+    <xacro:arg name="robot_type" default="Rizon4" />
     <xacro:arg name="robot_sn" default="" />
     <xacro:arg name="load_gripper" default="false" />
     <xacro:arg name="load_mounted_ft_sensor" default="false" />
 
     <xacro:include filename="$(find flexiv_moveit_config)/srdf/rizon_macro.srdf.xacro" />
-    <xacro:rizon_srdf arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)"
+
+    <xacro:compute_prefix robot_sn="$(arg robot_sn)" />
+    <xacro:property name="prefix" value="${computed_prefix}" lazy_eval="false" />
+
+    <xacro:rizon_srdf prefix="${prefix}"
         load_mounted_ft_sensor="$(arg load_mounted_ft_sensor)" />
 
     <!-- Load gripper -->
     <xacro:if value="$(arg load_gripper)">
         <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
-        <xacro:grav_srdf arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)"
+        <xacro:grav_srdf prefix="${prefix}"
             load_mounted_ft_sensor="$(arg load_mounted_ft_sensor)" />
     </xacro:if>
 

--- a/flexiv_moveit_config/srdf/rizon_dual.srdf.xacro
+++ b/flexiv_moveit_config/srdf/rizon_dual.srdf.xacro
@@ -7,22 +7,25 @@
     <xacro:arg name="load_gripper_right" default="false" />
     <xacro:arg name="load_mounted_ft_sensor_left" default="false" />
     <xacro:arg name="load_mounted_ft_sensor_right" default="false" />
-    <xacro:arg name="prefix_left" default="left_" />
-    <xacro:arg name="prefix_right" default="right_" />
+    <!-- Side names carry no trailing underscore; compute_prefix inserts the separator. -->
+    <xacro:arg name="prefix_left" default="left" />
+    <xacro:arg name="prefix_right" default="right" />
 
     <xacro:include filename="$(find flexiv_moveit_config)/srdf/rizon_macro.srdf.xacro" />
 
+    <!-- Arm Prefixes. lazy_eval is off so each capture resolves before the next call. -->
+    <xacro:compute_prefix side="$(arg prefix_left)" robot_sn="$(arg robot_sn_left)" />
+    <xacro:property name="left_arm_prefix" value="${computed_prefix}" lazy_eval="false" />
+    <xacro:compute_prefix side="$(arg prefix_right)" robot_sn="$(arg robot_sn_right)" />
+    <xacro:property name="right_arm_prefix" value="${computed_prefix}" lazy_eval="false" />
+
     <!-- Left Arm -->
-    <xacro:rizon_srdf arm_prefix="$(arg prefix_left)" robot_sn="$(arg robot_sn_left)"
+    <xacro:rizon_srdf prefix="${left_arm_prefix}"
         load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_left)" />
 
     <!-- Right Arm -->
-    <xacro:rizon_srdf arm_prefix="$(arg prefix_right)" robot_sn="$(arg robot_sn_right)"
+    <xacro:rizon_srdf prefix="${right_arm_prefix}"
         load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_right)" />
-
-    <!-- Arm Prefixes -->
-    <xacro:property name="left_arm_prefix" value="$(arg prefix_left)$(arg robot_sn_left)_" />
-    <xacro:property name="right_arm_prefix" value="$(arg prefix_right)$(arg robot_sn_right)_" />
 
     <!-- Left and Right Arms Collisions -->
     <disable_collisions link1="${left_arm_prefix}base_link" link2="${right_arm_prefix}base_link" reason="Never" />
@@ -31,13 +34,13 @@
     <!-- Load grippers -->
     <xacro:if value="$(arg load_gripper_left)">
         <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
-        <xacro:grav_srdf arm_prefix="$(arg prefix_left)" robot_sn="$(arg robot_sn_left)"
+        <xacro:grav_srdf prefix="${left_arm_prefix}"
             load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_left)" />
     </xacro:if>
 
     <xacro:if value="$(arg load_gripper_right)">
         <xacro:include filename="$(find flexiv_moveit_config)/srdf/grav.srdf.xacro" />
-        <xacro:grav_srdf arm_prefix="$(arg prefix_right)" robot_sn="$(arg robot_sn_right)"
+        <xacro:grav_srdf prefix="${right_arm_prefix}"
             load_mounted_ft_sensor="$(arg load_mounted_ft_sensor_right)" />
     </xacro:if>
 

--- a/flexiv_moveit_config/srdf/rizon_macro.srdf.xacro
+++ b/flexiv_moveit_config/srdf/rizon_macro.srdf.xacro
@@ -1,8 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="rizon_srdf" params="arm_prefix robot_sn load_mounted_ft_sensor use_virtual_joint:=true">
-        <!-- Prefix defaults to 'arm_prefix_robot_sn' -->
-        <xacro:property name="prefix" value="${arm_prefix + robot_sn + '_'}" />
+    <!--
+        Build a link/joint name prefix from a side name and a serial number, and expose
+        it to the caller as 'computed_prefix'.
+
+        Mirrors compute_arm_prefix in flexiv_description's flexiv_common.xacro and must
+        stay in step with it: the separating underscore only appears when the part it
+        separates is non-empty. Concatenating unconditionally yields 'left__base_link'
+        for an empty robot_sn where the URDF creates 'left_base_link'.
+
+        side:     'left', 'right' or '' (no trailing underscore)
+        robot_sn: robot serial number, may be empty
+    -->
+    <xacro:macro name="compute_prefix" params="side:='' robot_sn:=''">
+        <xacro:property name="computed_prefix"
+            value="${(side + '_' + robot_sn + '_') if side != '' and robot_sn != '' else (side + robot_sn + '_') if (side + robot_sn) != '' else ''}"
+            scope="parent" />
+    </xacro:macro>
+
+    <!-- 'prefix' is the fully-formed prefix, normally from compute_prefix above. -->
+    <xacro:macro name="rizon_srdf" params="prefix load_mounted_ft_sensor use_virtual_joint:=true">
 
         <group name="${prefix}arm">
             <chain base_link="${prefix}base_link" tip_link="${prefix}flange" />


### PR DESCRIPTION
Adapts this workspace to the consolidated `flexiv_description` repo https://github.com/flexivrobotics/flexiv_description/pull/30, which unifies all robot models under one package.

- **Point description dependency at consolidated repo** — `flexiv.humble.repos` now tracks `humble-v3.0`.
- **Move `ros2_control` xacros into `flexiv_hardware`** — adds `flexiv.ros2_control.xacro`, `rizon_dual.ros2_control.xacro`, and `flexiv.urdf.xacro`; these are hardware-interface concerns, not description concerns.
- **Unify launch args** — replace `rizon_type` and `external_axis_type` with a single `robot_type` across all bringup launch files (rizon, dual, aico1/2, + moveit variants).
- **Derive SRDF prefixes from one shared rule** — dedupe prefix logic across `rizon`, `rizon_dual`, `aico1`, `aico2`, `grav` SRDF xacros.
- **Update README** — reflect new `robot_type` arg and example commands.