### PR TITLE
Task/Adapt to consolidated flexiv_description (jazzy-v2.2)

### DIFF
--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and install flexiv_rdk
         shell: bash
         run: |
-          git clone --branch v2.1 --depth 1 https://github.com/flexivrobotics/flexiv_rdk.git
+          git clone --branch release/v2.2 --depth 1 https://github.com/flexivrobotics/flexiv_rdk.git
           cd flexiv_rdk/thirdparty
           bash build_and_install_dependencies.sh "${RDK_INSTALL_PREFIX}"
           cd ..

--- a/flexiv.jazzy.repos
+++ b/flexiv.jazzy.repos
@@ -2,7 +2,7 @@ repositories:
   flexiv_description:
     type: git
     url: https://github.com/flexivrobotics/flexiv_description.git
-    version: jazzy-v2.1
+    version: jazzy
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git

--- a/flexiv.jazzy.repos
+++ b/flexiv.jazzy.repos
@@ -6,4 +6,4 @@ repositories:
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git
-    version: v2.1
+    version: release/v2.2

--- a/flexiv.jazzy.repos
+++ b/flexiv.jazzy.repos
@@ -2,7 +2,7 @@ repositories:
   flexiv_description:
     type: git
     url: https://github.com/flexivrobotics/flexiv_description.git
-    version: jazzy
+    version: jazzy-v3.0
   flexiv_rdk:
     type: git
     url: https://github.com/flexivrobotics/flexiv_rdk.git

--- a/flexiv_bringup/launch/flexiv.launch.py
+++ b/flexiv_bringup/launch/flexiv.launch.py
@@ -58,7 +58,7 @@ def launch_setup(context):
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "flexiv.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
     robot_description_content = ParameterValue(
         Command(

--- a/flexiv_bringup/launch/flexiv_moveit.launch.py
+++ b/flexiv_bringup/launch/flexiv_moveit.launch.py
@@ -82,7 +82,7 @@ def launch_setup(context):
 
     # Get URDF via xacro
     flexiv_urdf_xacro = PathJoinSubstitution(
-        [FindPackageShare("flexiv_description"), "urdf", "flexiv.urdf.xacro"]
+        [FindPackageShare("flexiv_hardware"), "urdf", "flexiv.urdf.xacro"]
     )
 
     # Get URDF via xacro

--- a/flexiv_bringup/package.xml
+++ b/flexiv_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_bringup</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>Package with launch files and run-time configurations for Flexiv robots with `ros2_control`</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/flexiv_robot_states_broadcaster/package.xml
+++ b/flexiv_controllers/flexiv_robot_states_broadcaster/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_robot_states_broadcaster</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>The robot states broadcaster publishes the Flexiv robot states.</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/gpio_controller/CMakeLists.txt
+++ b/flexiv_controllers/gpio_controller/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(gpio_controller LANGUAGES CXX)
 
-# Default to C++14
+# Default to C++20
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -20,6 +21,7 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(realtime_tools REQUIRED)
+find_package(flexiv_rdk REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   builtin_interfaces
@@ -46,6 +48,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE include)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
   gpio_controller_parameters
+  flexiv::flexiv_rdk
 )
 
 ament_target_dependencies(${PROJECT_NAME} PUBLIC

--- a/flexiv_controllers/gpio_controller/package.xml
+++ b/flexiv_controllers/gpio_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gpio_controller</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>Flexiv custom gpio controller to control the GPIOs of the robot.</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_controllers/gpio_controller/package.xml
+++ b/flexiv_controllers/gpio_controller/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>realtime_tools</depend>
+  <depend>flexiv_rdk</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/flexiv_gripper/package.xml
+++ b/flexiv_gripper/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_gripper</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>Package implementing the action server of Flexiv gripper control</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_gripper/src/gripper_action_server.cpp
+++ b/flexiv_gripper/src/gripper_action_server.cpp
@@ -25,7 +25,7 @@ flexiv::rdk::JointGroup ResolveJointGroup(const std::string& group_name,
             "Parameter 'joint_group' must be specified (e.g. ARM_1 or ARM_2) because the connected "
             "robot reports multiple single-arm groups");
     }
-    for (const auto& [group, name] : flexiv::rdk::kJointGroupNames) {
+    for (const auto& [group, name] : flexiv::rdk::JointGroupNames()) {
         if (name == group_name) {
             if (single_arm_groups.count(group) == 0) {
                 throw std::invalid_argument("Joint group '" + group_name
@@ -116,7 +116,7 @@ GripperActionServer::GripperActionServer(const rclcpp::NodeOptions& options)
         const std::string joint_group_name = this->get_parameter("joint_group").as_string();
         this->joint_group_ = ResolveJointGroup(joint_group_name, robot_->info().single_arm_groups);
         RCLCPP_INFO(this->get_logger(), "Controlling gripper for joint group [%s]",
-            flexiv::rdk::kJointGroupNames.at(joint_group_).c_str());
+            flexiv::rdk::JointGroupNames().at(joint_group_).c_str());
 
         RCLCPP_INFO(this->get_logger(), "Initializing Flexiv gripper control interface");
         this->gripper_ = std::make_unique<flexiv::rdk::Gripper>(*robot_);

--- a/flexiv_hardware/CMakeLists.txt
+++ b/flexiv_hardware/CMakeLists.txt
@@ -58,6 +58,11 @@ install(
   DESTINATION include
 )
 
+install(
+  DIRECTORY ros2_control urdf
+  DESTINATION share/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 endif()

--- a/flexiv_hardware/package.xml
+++ b/flexiv_hardware/package.xml
@@ -15,6 +15,9 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
 
+  <exec_depend>flexiv_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/flexiv_hardware/package.xml
+++ b/flexiv_hardware/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_hardware</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>Hardware interfaces to Flexiv robots for ROS 2 control</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache 2.0</license>

--- a/flexiv_hardware/ros2_control/flexiv.ros2_control.xacro
+++ b/flexiv_hardware/ros2_control/flexiv.ros2_control.xacro
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- Single-arm ros2_control: one robot_sn, one FlexivHardwareInterface. -->
+  <xacro:macro name="flexiv_ros2_control"
+    params="
+    prefix
+    robot_sn
+    rdk_control_mode:='joint_position'
+    use_fake_hardware:=false
+    fake_sensor_commands:=false
+    initial_positions_file
+    num_gpio_ports:=20
+    ">
+
+    <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
+
+    <xacro:include filename="$(find flexiv_description)/urdf/common/flexiv_common.xacro" />
+    <!-- GPIO belongs to the control box, not to an arm, so it is named from robot_sn
+         alone. The hardware interface builds it as robot_sn + "_gpio" regardless of
+         any arm prefix. -->
+    <xacro:compute_arm_prefix robot_sn="${robot_sn}" />
+    <xacro:property name="sn_prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+
+    <ros2_control name="FlexivHardwareInterface" type="system">
+      <hardware>
+        <xacro:if value="${use_fake_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">${fake_sensor_commands}</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:unless value="${use_fake_hardware}">
+          <plugin>flexiv_hardware/FlexivHardwareInterface</plugin>
+          <param name="robot_sn">${robot_sn}</param>
+          <param name="prefix">${prefix}</param>
+          <param name="rdk_control_mode">${rdk_control_mode}</param>
+        </xacro:unless>
+      </hardware>
+
+      <joint name="${prefix}joint1">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint1']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint2">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint2']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint3">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint3']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint4">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint4']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint5">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint5']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint6">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint6']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+      <joint name="${prefix}joint7">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['joint7']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+
+      <!-- Digital IO ports: 16 on the control box plus 2 in each wrist connector.
+           Enlight-L and MICO have two wrist connectors (20); Rizon has one (18). -->
+      <xacro:macro name="loop_gpio" params="idx">
+        <command_interface name="digital_output_${idx}" />
+        <state_interface name="digital_input_${idx}" />
+        <xacro:if value="${idx &lt; num_gpio_ports - 1}">
+          <xacro:loop_gpio idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <gpio name="${sn_prefix}gpio">
+        <xacro:loop_gpio idx="0" />
+      </gpio>
+
+    </ros2_control>
+  </xacro:macro>
+</robot>

--- a/flexiv_hardware/ros2_control/flexiv_dual.ros2_control.xacro
+++ b/flexiv_hardware/ros2_control/flexiv_dual.ros2_control.xacro
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!--
+    Dual-arm ros2_control for Flexiv dual-arm products (Enlight-LL, MICO-*).
+
+    A dual-arm robot is ONE RDK connection that reports two joint groups (ARM_1, ARM_2). It is
+    therefore driven by the SAME unified plugin (flexiv_hardware/FlexivHardwareInterface) as the
+    single-arm case, with a single robot_sn plus prefix_left/prefix_right so the hardware interface
+    can map ARM_1 -> left arm joints and ARM_2 -> right arm joints.
+  -->
+  <xacro:macro name="flexiv_dual_ros2_control"
+    params="
+    prefix_left
+    prefix_right
+    robot_sn
+    rdk_control_mode:='joint_position'
+    use_fake_hardware:=false
+    fake_sensor_commands:=false
+    initial_positions_file_left
+    initial_positions_file_right
+    ">
+
+    <xacro:include filename="$(find flexiv_description)/urdf/common/flexiv_common.xacro" />
+    <!-- Same omit-separator rule as the arm prefixes, so these names match the ones
+         the model files generate even when robot_sn is empty. -->
+    <xacro:compute_arm_prefix robot_sn="${robot_sn}" />
+    <xacro:property name="sn_prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+
+    <xacro:property name="initial_positions_left"
+      value="${xacro.load_yaml(initial_positions_file_left)['initial_positions']}" />
+    <xacro:property name="initial_positions_right"
+      value="${xacro.load_yaml(initial_positions_file_right)['initial_positions']}" />
+
+    <ros2_control name="FlexivHardwareInterface" type="system">
+      <hardware>
+        <xacro:if value="${use_fake_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">${fake_sensor_commands}</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:unless value="${use_fake_hardware}">
+          <plugin>flexiv_hardware/FlexivHardwareInterface</plugin>
+          <param name="robot_sn">${robot_sn}</param>
+          <param name="prefix_left">${prefix_left}</param>
+          <param name="prefix_right">${prefix_right}</param>
+          <param name="rdk_control_mode">${rdk_control_mode}</param>
+        </xacro:unless>
+      </hardware>
+
+      <!-- Per-arm joint loop: emits joint1..joint7 for one arm prefix. -->
+      <xacro:macro name="dual_arm_joints" params="arm_prefix initial_positions idx:=1">
+        <joint name="${arm_prefix}joint${idx}">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">${initial_positions['joint' + str(idx)]}</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+        <xacro:if value="${idx &lt; 7}">
+          <xacro:dual_arm_joints arm_prefix="${arm_prefix}" initial_positions="${initial_positions}"
+            idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <xacro:dual_arm_joints arm_prefix="${prefix_left}" initial_positions="${initial_positions_left}" />
+      <xacro:dual_arm_joints arm_prefix="${prefix_right}" initial_positions="${initial_positions_right}" />
+
+      <!-- Single GPIO block for the whole robot. The unified hardware interface names GPIO
+           interfaces "<robot_sn>_gpio" (or "gpio" when robot_sn is empty) regardless of
+           arm count. -->
+      <xacro:macro name="loop_gpio" params="idx">
+        <command_interface name="digital_output_${idx}" />
+        <state_interface name="digital_input_${idx}" />
+        <xacro:if value="${idx &lt; 19}">
+          <xacro:loop_gpio idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <gpio name="${sn_prefix}gpio">
+        <xacro:loop_gpio idx="0" />
+      </gpio>
+
+    </ros2_control>
+  </xacro:macro>
+</robot>

--- a/flexiv_hardware/ros2_control/flexiv_mico.ros2_control.xacro
+++ b/flexiv_hardware/ros2_control/flexiv_mico.ros2_control.xacro
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!--
+    MICO-Plus / MICO-Ultra ros2_control: mirrors flexiv_dual_ros2_control but additionally emits
+    the 2 torso revolute joints, named "<robot_sn>_torso_joint1/2" (or "torso_joint1/2"
+    when robot_sn is empty). The torso joint prefix intentionally differs from
+    left_/right_ so the hardware interface classifies them as external-axis joints.
+  -->
+  <xacro:macro name="flexiv_mico_ros2_control"
+    params="
+    prefix_left
+    prefix_right
+    robot_sn
+    rdk_control_mode:='joint_position'
+    use_fake_hardware:=false
+    fake_sensor_commands:=false
+    initial_positions_file_left
+    initial_positions_file_right
+    torso_initial_positions_file
+    ">
+
+    <xacro:include filename="$(find flexiv_description)/urdf/common/flexiv_common.xacro" />
+    <!-- Same omit-separator rule as the arm prefixes, so these names match the ones
+         the model files generate even when robot_sn is empty. -->
+    <xacro:compute_arm_prefix robot_sn="${robot_sn}" />
+    <xacro:property name="sn_prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+
+    <xacro:property name="initial_positions_left"
+      value="${xacro.load_yaml(initial_positions_file_left)['initial_positions']}" />
+    <xacro:property name="initial_positions_right"
+      value="${xacro.load_yaml(initial_positions_file_right)['initial_positions']}" />
+    <xacro:property name="torso_initial_positions"
+      value="${xacro.load_yaml(torso_initial_positions_file)['initial_positions']}" />
+
+    <ros2_control name="FlexivHardwareInterface" type="system">
+      <hardware>
+        <xacro:if value="${use_fake_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">${fake_sensor_commands}</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:unless value="${use_fake_hardware}">
+          <plugin>flexiv_hardware/FlexivHardwareInterface</plugin>
+          <param name="robot_sn">${robot_sn}</param>
+          <param name="prefix_left">${prefix_left}</param>
+          <param name="prefix_right">${prefix_right}</param>
+          <param name="rdk_control_mode">${rdk_control_mode}</param>
+        </xacro:unless>
+      </hardware>
+
+      <!-- Per-arm joint loop: emits joint1..joint7 for one arm prefix. -->
+      <xacro:macro name="mico_arm_joints" params="arm_prefix initial_positions idx:=1">
+        <joint name="${arm_prefix}joint${idx}">
+          <command_interface name="position" />
+          <command_interface name="velocity" />
+          <command_interface name="effort" />
+          <state_interface name="position">
+            <param name="initial_value">${initial_positions['joint' + str(idx)]}</param>
+          </state_interface>
+          <state_interface name="velocity" />
+          <state_interface name="effort" />
+        </joint>
+        <xacro:if value="${idx &lt; 7}">
+          <xacro:mico_arm_joints arm_prefix="${arm_prefix}" initial_positions="${initial_positions}"
+            idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <xacro:mico_arm_joints arm_prefix="${prefix_left}" initial_positions="${initial_positions_left}" />
+      <xacro:mico_arm_joints arm_prefix="${prefix_right}" initial_positions="${initial_positions_right}" />
+
+      <!-- Torso joints: classified as external-axis joints by the hardware interface. -->
+      <joint name="${sn_prefix}torso_joint1">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${torso_initial_positions['joint1']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+
+      <joint name="${sn_prefix}torso_joint2">
+        <command_interface name="position" />
+        <command_interface name="velocity" />
+        <command_interface name="effort" />
+        <state_interface name="position">
+          <param name="initial_value">${torso_initial_positions['joint2']}</param>
+        </state_interface>
+        <state_interface name="velocity" />
+        <state_interface name="effort" />
+      </joint>
+
+      <!-- Single GPIO block for the whole robot. 20 ports -->
+      <xacro:macro name="mico_loop_gpio" params="idx">
+        <command_interface name="digital_output_${idx}" />
+        <state_interface name="digital_input_${idx}" />
+        <xacro:if value="${idx &lt; 19}">
+          <xacro:mico_loop_gpio idx="${idx+1}" />
+        </xacro:if>
+      </xacro:macro>
+
+      <gpio name="${sn_prefix}gpio">
+        <xacro:mico_loop_gpio idx="0" />
+      </gpio>
+
+    </ros2_control>
+  </xacro:macro>
+</robot>

--- a/flexiv_hardware/src/flexiv_hardware_interface.cpp
+++ b/flexiv_hardware/src/flexiv_hardware_interface.cpp
@@ -57,8 +57,9 @@ std::string get_optional_hardware_parameter(
 
 std::string joint_group_name_string(flexiv::rdk::JointGroup group)
 {
-    const auto name_it = flexiv::rdk::kJointGroupNames.find(group);
-    if (name_it != flexiv::rdk::kJointGroupNames.end()) {
+    const auto& group_names = flexiv::rdk::JointGroupNames();
+    const auto name_it = group_names.find(group);
+    if (name_it != group_names.end()) {
         return name_it->second;
     }
     return "GROUP_" + std::to_string(static_cast<int>(group));

--- a/flexiv_hardware/urdf/flexiv.urdf.xacro
+++ b/flexiv_hardware/urdf/flexiv.urdf.xacro
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  flexiv_description model + the ros2_control block for flexiv_hardware.
+  Use flexiv_description's entry point for visualization, this one for control.
+
+  This release supports the Enlight and MICO models only. flexiv_description hosts
+  every Flexiv model, so asking for an unsupported one is rejected below.
+
+  robot_type must be passed on the command line: it names the robot element,
+  which xacro resolves before <xacro:arg> defaults are read.
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="$(arg robot_type)">
+
+  <xacro:arg name="robot_type" default="Enlight-L" />
+
+  <!-- Other args come from the description entry point included below. -->
+  <xacro:arg name="ros2_control" default="true" />
+  <xacro:arg name="rdk_control_mode" default="joint_position" />
+  <xacro:arg name="use_fake_hardware" default="false" />
+  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="initial_positions_file" default="" />
+
+  <!-- Robot model, including the arg declarations this file relies on
+       (robot_sn, arm_prefix). -->
+  <xacro:include filename="$(find flexiv_description)/urdf/flexiv.urdf.xacro" />
+
+  <xacro:if value="$(arg ros2_control)">
+    <xacro:include filename="$(find flexiv_description)/urdf/common/flexiv_common.xacro" />
+    <xacro:include filename="$(find flexiv_hardware)/ros2_control/flexiv.ros2_control.xacro" />
+    <xacro:include filename="$(find flexiv_hardware)/ros2_control/flexiv_dual.ros2_control.xacro" />
+    <xacro:include filename="$(find flexiv_hardware)/ros2_control/flexiv_mico.ros2_control.xacro" />
+
+    <xacro:property name="cfg" value="$(find flexiv_description)/config" />
+    <xacro:property name="rtype" value="$(arg robot_type)" />
+
+    <xacro:property name="is_single" value="${rtype == 'Enlight-L'}" />
+    <xacro:property name="is_enlight_ll" value="${rtype == 'Enlight-LL'}" />
+    <xacro:property name="is_mico_core" value="${rtype == 'MICO-Core'}" />
+    <xacro:property name="is_mico_torso" value="${rtype in ['MICO-Plus', 'MICO-Ultra']}" />
+
+    <xacro:unless value="${is_single or is_enlight_ll or is_mico_core or is_mico_torso}">
+      ${xacro.error('robot_type ' + rtype + ' is not supported by this release. Supported: '
+        + 'Enlight-L, Enlight-LL, MICO-Core, MICO-Plus, MICO-Ultra')}
+    </xacro:unless>
+
+    <!-- Enlight-L has 20 digital IO ports: 16 on the control box plus 2 in each of
+         its two wrist connectors. -->
+    <xacro:property name="num_gpio_ports" value="20" />
+    <xacro:property name="arm_init" value="${cfg}/Enlight-L/initial_positions.yaml" />
+    <xacro:property name="arm_init_mirrored"
+      value="${cfg}/Enlight-L/initial_positions_mirrored.yaml" />
+
+    <!-- ===================== SINGLE ARM (Enlight-L) ===================== -->
+    <xacro:if value="${is_single}">
+      <xacro:compute_arm_prefix arm_prefix="$(arg arm_prefix)" robot_sn="$(arg robot_sn)" />
+      <xacro:property name="prefix" value="${computed_arm_prefix}" lazy_eval="false" />
+      <xacro:property name="init_file"
+        value="${'$(arg initial_positions_file)' if '$(arg initial_positions_file)' != '' else arm_init}" />
+
+      <xacro:flexiv_ros2_control
+        prefix="${prefix}"
+        robot_sn="$(arg robot_sn)"
+        rdk_control_mode="$(arg rdk_control_mode)"
+        use_fake_hardware="$(arg use_fake_hardware)"
+        fake_sensor_commands="$(arg fake_sensor_commands)"
+        initial_positions_file="${init_file}"
+        num_gpio_ports="${num_gpio_ports}" />
+    </xacro:if>
+
+    <!-- ============ ONE ROBOT WITH TWO ARMS (Enlight-LL, MICO) ============ -->
+    <xacro:if value="${is_enlight_ll or is_mico_core or is_mico_torso}">
+      <xacro:compute_arm_prefix arm_prefix="left" robot_sn="$(arg robot_sn)" />
+      <xacro:property name="prefix_left" value="${computed_arm_prefix}" lazy_eval="false" />
+      <xacro:compute_arm_prefix arm_prefix="right" robot_sn="$(arg robot_sn)" />
+      <xacro:property name="prefix_right" value="${computed_arm_prefix}" lazy_eval="false" />
+
+      <!-- Enlight-LL mirrors nothing; the MICO arms face each other. -->
+      <xacro:property name="init_right" value="${arm_init if is_enlight_ll else arm_init_mirrored}" />
+
+      <!-- MICO-Plus and MICO-Ultra add two actuated torso joints. -->
+      <xacro:unless value="${is_mico_torso}">
+        <xacro:flexiv_dual_ros2_control
+          prefix_left="${prefix_left}"
+          prefix_right="${prefix_right}"
+          robot_sn="$(arg robot_sn)"
+          rdk_control_mode="$(arg rdk_control_mode)"
+          use_fake_hardware="$(arg use_fake_hardware)"
+          fake_sensor_commands="$(arg fake_sensor_commands)"
+          initial_positions_file_left="${arm_init}"
+          initial_positions_file_right="${init_right}" />
+      </xacro:unless>
+
+      <xacro:if value="${is_mico_torso}">
+        <xacro:flexiv_mico_ros2_control
+          prefix_left="${prefix_left}"
+          prefix_right="${prefix_right}"
+          robot_sn="$(arg robot_sn)"
+          rdk_control_mode="$(arg rdk_control_mode)"
+          use_fake_hardware="$(arg use_fake_hardware)"
+          fake_sensor_commands="$(arg fake_sensor_commands)"
+          initial_positions_file_left="${arm_init}"
+          initial_positions_file_right="${init_right}"
+          torso_initial_positions_file="${cfg}/${rtype}/torso_initial_positions.yaml" />
+      </xacro:if>
+    </xacro:if>
+  </xacro:if>
+
+</robot>

--- a/flexiv_moveit_config/package.xml
+++ b/flexiv_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_moveit_config</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>MoveIt2 configuration and launch files for Flexiv Enlight series robots</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache 2.0</license>

--- a/flexiv_msgs/package.xml
+++ b/flexiv_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_msgs</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>Robot states messages definiton used in RDK</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache License 2.0</license>

--- a/flexiv_test_nodes/package.xml
+++ b/flexiv_test_nodes/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>flexiv_test_nodes</name>
-  <version>2.0.0</version>
+  <version>2.2.0</version>
   <description>Demo nodes for testing flexiv_ros2</description>
   <maintainer email="munseng.phoon@flexiv.com">Mun Seng Phoon</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
Forward-port of https://github.com/flexivrobotics/flexiv_ros2/pull/115 to Jazzy.

Adapts this workspace to the consolidated `flexiv_description` repo (https://github.com/flexivrobotics/flexiv_description/pull/31) and updates it for RDK v2.2 API changes.